### PR TITLE
Compatibility update for ROS Indigo.

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_focus
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_focus
@@ -19,7 +19,7 @@ class CameraFocus:
     def callback(self, msg):
         #convert image to opencv
         try:
-            cv_image = self.bridge.imgmsg_to_cv(msg)
+            cv_image = self.bridge.imgmsg_to_cv2(msg)
             np_image= np.array(cv_image)
         except CvBridgeError, e:
             print "Could not convert ros message to opencv image: ", e

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
@@ -121,7 +121,7 @@ class CameraChainValidator(object):
         for cam_nr, msg in enumerate(cam_msgs):
             #convert image to numpy
             try:
-                cv_image = self.bridge.imgmsg_to_cv(msg)
+                cv_image = self.bridge.imgmsg_to_cv2(msg)
                 np_image = np.array(cv_image)
             except CvBridgeError, e:
                 print e

--- a/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
@@ -114,6 +114,6 @@ class BagImageDatasetReader(object):
             img_data = np.reshape(self.uncompress(np.fromstring(data.data, dtype='uint8')),(data.height,data.width), order="C")
             
         else:
-            img_data = np.array(self.CVB.imgmsg_to_cv(data))  
+            img_data = np.array(self.CVB.imgmsg_to_cv2(data))  
         return (ts, img_data)
      


### PR DESCRIPTION
CvBridge does not have the imgmsg_to_cv function anymore, but it is
renamed to imgmsg_to_cv2. Now this change is reflected in the code as well.