### PR TITLE
CMake finds correct Eigen config in Ubuntu 14.04.

### DIFF
--- a/Schweizer-Messer/numpy_eigen/CMakeLists.txt
+++ b/Schweizer-Messer/numpy_eigen/CMakeLists.txt
@@ -4,12 +4,12 @@ project(numpy_eigen)
 find_package(catkin REQUIRED COMPONENTS python_module)
 include_directories(${catkin_INCLUDE_DIRS})
 find_package(Boost REQUIRED COMPONENTS system)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 catkin_python_setup()
 
 add_definitions(${EIGEN_DEFINITIONS})
-include_directories(include ${Eigen_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(include ${EIGEN3_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 include_directories("${PROJECT_SOURCE_DIR}/include/numpy_eigen")
 
 catkin_package(

--- a/Schweizer-Messer/sm_eigen/CMakeLists.txt
+++ b/Schweizer-Messer/sm_eigen/CMakeLists.txt
@@ -4,12 +4,12 @@ project(sm_eigen)
 find_package(catkin REQUIRED COMPONENTS sm_common sm_random)
 include_directories(${catkin_INCLUDE_DIRS})
 find_package(Boost REQUIRED COMPONENTS system serialization)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
-include_directories(include ${Eigen_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(include ${EIGEN3_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 catkin_package(
-  INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS}
+  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS 
   DEPENDS

--- a/Schweizer-Messer/sm_eigen/include/sm/eigen/random.hpp
+++ b/Schweizer-Messer/sm_eigen/include/sm/eigen/random.hpp
@@ -1,5 +1,6 @@
 #ifndef SM_EIGEN_RANDOM_HPP
 #define SM_EIGEN_RANDOM_HPP
+#include <eigen3/Eigen/Dense>
 #include <Eigen/Core>
 
 namespace sm {

--- a/Schweizer-Messer/sm_kinematics/CMakeLists.txt
+++ b/Schweizer-Messer/sm_kinematics/CMakeLists.txt
@@ -6,8 +6,8 @@ include_directories(${catkin_INCLUDE_DIRS})
 find_package(Boost REQUIRED COMPONENTS system serialization filesystem)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
-find_package(Eigen REQUIRED)
-include_directories(${EIGEN_INCLUDE_DIRS})
+find_package(Eigen3 REQUIRED)
+include_directories(${EIGEN3_INCLUDE_DIR})
 add_definitions(${EIGEN_DEFINITIONS})
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++0x")

--- a/Schweizer-Messer/sm_matrix_archive/CMakeLists.txt
+++ b/Schweizer-Messer/sm_matrix_archive/CMakeLists.txt
@@ -5,8 +5,8 @@ find_package(catkin REQUIRED COMPONENTS sm_common)
 include_directories(${catkin_INCLUDE_DIRS})
 find_package(Boost REQUIRED COMPONENTS system filesystem)
 
-find_package(Eigen REQUIRED)
-include_directories(include ${Eigen_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+find_package(Eigen3 REQUIRED)
+include_directories(include ${EIGEN3_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include  ${catkin_INCLUDE_DIRS}

--- a/Schweizer-Messer/sm_python/CMakeLists.txt
+++ b/Schweizer-Messer/sm_python/CMakeLists.txt
@@ -7,9 +7,9 @@ find_package(catkin REQUIRED COMPONENTS sm_common numpy_eigen sm_kinematics
                                         sm_timing sm_logging sm_matrix_archive
                                         sm_property_tree python_module)
 include_directories(${catkin_INCLUDE_DIRS})
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
-include_directories(include ${Eigen_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(include ${EIGEN3_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 
 catkin_package(

--- a/aslam_cv/aslam_cameras_april/CMakeLists.txt
+++ b/aslam_cv/aslam_cameras_april/CMakeLists.txt
@@ -7,7 +7,7 @@ catkin_simple()
 find_package(OpenCV REQUIRED)
 
 ADD_DEFINITIONS(-DASLAM_USE_ROS )
-include_directories(${Eigen_INCLUDE_DIRS})
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 
 cs_add_library(${PROJECT_NAME} 

--- a/aslam_cv/aslam_imgproc/CMakeLists.txt
+++ b/aslam_cv/aslam_imgproc/CMakeLists.txt
@@ -7,7 +7,7 @@ catkin_simple()
 
 find_package(Boost REQUIRED COMPONENTS system)
 
-include_directories(${Eigen_INCLUDE_DIRS})
+include_directories(${EIGEN3_INCLUDE_DIR})
 cs_add_library(${PROJECT_NAME} src/UndistorterBase.cpp)
 
 

--- a/aslam_offline_calibration/ethz_apriltag2/CMakeLists.txt
+++ b/aslam_offline_calibration/ethz_apriltag2/CMakeLists.txt
@@ -5,21 +5,21 @@ project(ethz_apriltag2)
 find_package(catkin)
 include_directories(${catkin_INCLUDE_DIRS})
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 catkin_package(
     DEPENDS eigen opencv
-    INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS}
+    INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
     LIBRARIES ${PROJECT_NAME}
 )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/)
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
 
 add_definitions(-fPIC -O3)
-include_directories(include  ${Eigen_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(include  ${EIGEN3_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 if(NOT APPLE)
   # The clang compiler (on osx) is somehow much more strict

--- a/aslam_optimizer/aslam_backend/CMakeLists.txt
+++ b/aslam_optimizer/aslam_backend/CMakeLists.txt
@@ -6,7 +6,7 @@ catkin_simple()
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
-include_directories(${Eigen_INCLUDE_DIRS})
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 #add_definitions( -fPIC -msse2 -mssse3 -march=nocona -Wextra -Winit-self -Woverloaded-virtual -Wnon-virtual-dtor -Wsign-promo -Wno-long-long -std=c++0x -O3)
 

--- a/aslam_optimizer/aslam_backend_expressions/CMakeLists.txt
+++ b/aslam_optimizer/aslam_backend_expressions/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin_simple REQUIRED)
 
 catkin_simple()
 
-include_directories(${EIGEN_INCLUDE_DIRS})
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 find_package(Boost REQUIRED COMPONENTS system)
 


### PR DESCRIPTION
The installation tutorial instructs to install Eigen3.  A standard
Ubuntu installation has no FindEigen.cmake, but only FindEigen3.cmake.
Therefore, I instructed CMake to require Eigen3 instead of Eigen.
