### PR TITLE
Grayscale images sometimes problem in calibration.

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_common/TargetExtractor.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/TargetExtractor.py
@@ -18,6 +18,7 @@ def multicoreExtractionWrapper(detector, taskq, resultq, clearImages, noTransfor
         stamp = task[1]
         image = task[2]
         
+        image = image.reshape(filter(lambda dim: dim != 1, image.shape))
         if noTransformation:
             success, obs = detector.findTargetNoTransformation(stamp, np.array(image))
         else:


### PR DESCRIPTION
When the sensor_msgs/Image is converted to its numpy `ndarray`
representation, it sometimes has the shape `(n, m, 1)`.  This gives an
error even though it is a `sensor_msgs::image_encodings::MONO8`.

The underlying algorithm only supports 2D arrays, and the images were
stored as 3D objects.  Error:

```
TypeError: Conversion is only valid for arrays with 1 or 2
dimensions. Argument has 3 dimensions
```

Transforming the image with a reshape if and only if it has a dimension
of lenght 1 solves this problem.
