### PR TITLE
Add support for boost 1.58

### DIFF
--- a/Schweizer-Messer/sm_boost/include/boost/portable_binary_iarchive.hpp
+++ b/Schweizer-Messer/sm_boost/include/boost/portable_binary_iarchive.hpp
@@ -27,9 +27,13 @@
 #include <boost/archive/archive_exception.hpp>
 #include <boost/archive/basic_binary_iprimitive.hpp>
 #include <boost/archive/detail/common_iarchive.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 105600 // see changes in https://github.com/boostorg/serialization/commit/75f09afc895ab09c4eb55d36fcf6f91ef4a0107a
+#include <boost/serialization/shared_ptr.hpp>
+#else
 #include <boost/archive/shared_ptr_helper.hpp>
+#endif
 #include <boost/archive/detail/register_archive.hpp>
-
 #include "portable_binary_archive.hpp"
 
 namespace boost {
@@ -80,9 +84,12 @@ class portable_binary_iarchive :
     >,
     public boost::archive::detail::common_iarchive<
         portable_binary_iarchive
-    >
-    ,
+    >,
+#if BOOST_VERSION >= 105600 // see changes in https://github.com/boostorg/serialization/commit/75f09afc895ab09c4eb55d36fcf6f91ef4a0107a
+    public boost::serialization::shared_ptr_helper<boost::shared_ptr>
+#else
     public boost::archive::detail::shared_ptr_helper
+#endif
     {
     typedef boost::archive::basic_binary_iprimitive<
         portable_binary_iarchive,


### PR DESCRIPTION
Port some changes from ethz-asl/Schweizer-Messer to ethz-asl/kalibr to make kalibr compatible with boost 1.58. So this package will be usable with Ubuntu 16.04.
See ethz-asl/Schweizer-Messer#142