### PR TITLE
avoiding plotting the rig if there's only one cam

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
@@ -395,7 +395,7 @@ def main():
             print "Processed {0} images with {1} images used".format(numViews, calibrator.estimator.getNumBatches())
             kcc.printParameters(calibrator)
             
-            if parsed.verbose and len(calibrator.baselines)>1::
+            if parsed.verbose and len(calibrator.baselines)>1:
 		        f=pl.figure(100006)
 		        kcc.plotCameraRig(calibrator.baselines, fno=f.number, clearFigure=False)
 		        pl.show()

--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
@@ -395,7 +395,7 @@ def main():
             print "Processed {0} images with {1} images used".format(numViews, calibrator.estimator.getNumBatches())
             kcc.printParameters(calibrator)
             
-            if parsed.verbose:
+            if parsed.verbose and len(calibrator.baselines)>1::
 		        f=pl.figure(100006)
 		        kcc.plotCameraRig(calibrator.baselines, fno=f.number, clearFigure=False)
 		        pl.show()


### PR DESCRIPTION
single-cam with verbose caused the calibration to crash in the end because it tried to plot the camera rig, which does not make sense for a single cam setup (plotCameraRig(...) fails because baselines == [] and it tried to find a minimum in that list).
this change should help.