### PR TITLE
Fix/rs model support and option naming

### DIFF
--- a/aslam_cv/aslam_cv_backend_python/python/aslam_cv_backend/__init__.py
+++ b/aslam_cv/aslam_cv_backend_python/python/aslam_cv_backend/__init__.py
@@ -33,6 +33,7 @@ class DistortedOmniRs(CameraModel):
     projectionType = aslam_cv.DistortedOmniProjection
     distortionType = aslam_cv.RadialTangentialDistortion
     shutterType = aslam_cv.RollingShutter
+    frameType = aslam_cv.DistortedOmniRsFrame
 
 class DistortedPinhole(CameraModel):
     geometry = aslam_cv.DistortedPinholeCameraGeometry
@@ -74,6 +75,7 @@ class EquidistantPinholeRs(CameraModel):
     projectionType = aslam_cv.EquidistantPinholeProjection
     distortionType = aslam_cv.EquidistantDistortion
     shutterType = aslam_cv.RollingShutter
+    frameType = aslam_cv.EquidistantPinholeRsFrame
 
 class FovPinhole(CameraModel):
     geometry = aslam_cv.FovDistortedPinholeCameraGeometry

--- a/aslam_cv/aslam_cv_backend_python/src/module.cpp
+++ b/aslam_cv/aslam_cv_backend_python/src/module.cpp
@@ -7,6 +7,7 @@
 #include <aslam/cameras/OmniProjection.hpp>
 #include <aslam/cameras/NoDistortion.hpp>
 #include <aslam/cameras/RadialTangentialDistortion.hpp>
+#include <aslam/cameras/EquidistantDistortion.hpp>
 #include <aslam/cameras.hpp>
 #include <aslam/cameras/GlobalShutter.hpp>
 #include <aslam/cameras/RollingShutter.hpp>

--- a/aslam_cv/aslam_cv_python/src/Frame.cpp
+++ b/aslam_cv/aslam_cv_python/src/Frame.cpp
@@ -178,6 +178,9 @@ void exportFrame() {
   aslam::python::exportFrame<PinholeRsCameraGeometry>("PinholeRsFrame");
   aslam::python::exportFrame<DistortedPinholeRsCameraGeometry>(
       "DistortedPinholeRsFrame");
+  aslam::python::exportFrame<EquidistantDistortedPinholeRsCameraGeometry>(
+      "EquidistantPinholeRsFrame");
+  aslam::python::exportFrame<DistortedOmniRsCameraGeometry>("DistortedOmniRsFrame");
 
   //aslam::python::exportCovarianceReprojectionError<DistortedPinholeRsCameraGeometry>("DistortedPinholeRsFrameCovarianceReprojectionError");
 

--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_rs_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_rs_cameras
@@ -69,37 +69,39 @@ def __parseArgs():
     usage = """
     Example usage to calibrate a camera system with a single rolling shutter camera using an aprilgrid.
 
-    cam: pinhole model with radial-tangential distortion and rolling shutter
+    cam: pinhole model with radial-tangential distortion and rolling shutter for a single camera
 
-    %(prog)s --models pinhole-radtan-rs --target aprilgrid.yaml \\
-              --bag MYROSBAG.bag --topics /cam0/image_raw /cam1/image_raw
+    %(prog)s --model pinhole-radtan-rs --target aprilgrid.yaml \\
+              --bag MYROSBAG.bag --topic /cam0/image_raw \\
+              --feature-variance 1 --frame-rate 20
 
     example aprilgrid.yaml:
         target_type: 'aprilgrid'
         tagCols: 6
         tagRows: 6
         tagSize: 0.088  #m
-        tagSpacing: 0.3 #percent of tagSize"""
+        tagSpacing: 0.3 #as a fraction of tagSize"""
 
-    parser = KalibrArgParser(description='Calibrate the intrinsics and extrinsics of a rolling shutter camera.', usage=usage)
-    parser.add_argument('--model', dest='model', help='The camera model to estimate'.format(cameraModels.keys()), required=True)
-    parser.add_argument('--framerate', dest='framerate', type=int, help='Approximate framerate of the camera', required=True)
+    parser = KalibrArgParser(description='Calibrate the intrinsics of a single rolling shutter camera.', usage=usage)
+    parser.add_argument('--model', dest='model', help='The camera model to estimate. '
+                        'Currently supported models are {0}, where the suffix \'-rs\' identifies rolling shutter models.'.format(', '.join(cameraModels.keys())), required=True)
+    parser.add_argument('--frame-rate', dest='framerate', type=int, help='Approximate framerate of the camera.', required=True)
 
     groupSource = parser.add_argument_group('Data source')
-    groupSource.add_argument('--bag', dest='bagfile', help='The bag file with the data')
-    groupSource.add_argument('--topic', dest='topic', help='The image topic', required=True)
-    groupSource.add_argument('--bag-from-to', metavar='bag_from_to', type=float, nargs=2, help='Use the bag data starting from up to this time [s]')
+    groupSource.add_argument('--bag', dest='bagfile', help='The bag file with the data.')
+    groupSource.add_argument('--topic', dest='topic', help='The image topic.', required=True)
+    groupSource.add_argument('--bag-from-to', metavar='bag_from_to', type=float, nargs=2, help='Use the bag data starting from up to this time [s].')
 
     groupTarget = parser.add_argument_group('Calibration target configuration')
-    groupTarget.add_argument('--target', dest='targetYaml', help='Calibration target configuration as yaml file', required=True)
-    groupTarget.add_argument('--feature-variance', dest='inverseFeatureVariance', type=float, help='Variance of the feature detector', required=True)
+    groupTarget.add_argument('--target', dest='targetYaml', help='Calibration target configuration as yaml file.', required=True)
+    groupTarget.add_argument('--inverse-feature-variance', dest='inverseFeatureVariance', type=float, help='Estimated inverse variance of the feature detector.', required=True)
 
     groupOpt = parser.add_argument_group('Optimization options')
-    groupOpt.add_argument('--max-iter', type=int, default=30, dest='max_iter', help='Max. iterations (default: %(default)s)', required=False)
+    groupOpt.add_argument('--max-iter', type=int, default=30, dest='max_iter', help='Max. iterations (default: %(default)s).', required=False)
 
     outputSettings = parser.add_argument_group('Output options')
-    outputSettings.add_argument('--verbose', action='store_true', dest='verbose', help='Enable (really) verbose output (disables plots)')
-    outputSettings.add_argument('--show-extraction', action='store_true', dest='showextraction', help='Show the calibration target extraction. (disables plots)')
+    outputSettings.add_argument('--verbose', action='store_true', dest='verbose', help='Enable (really) verbose output (disables plots).')
+    outputSettings.add_argument('--show-extraction', action='store_true', dest='showextraction', help='Show the calibration target extraction. (disables plots).')
 
     # print help if no argument is specified
     if len(sys.argv)==1:

--- a/aslam_offline_calibration/kalibr/python/kalibr_rs_camera_calibration/RsCalibrator.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_rs_camera_calibration/RsCalibrator.py
@@ -451,6 +451,8 @@ class RsCalibrator(object):
             print "LineDelay:"
             print shutter.lineDelay()
         print "Intrinsics:"
-        print "(",proj.fu(),", ",proj.fv(),") (",proj.cu(),", ",proj.cv(),")"
+        print proj.getParameters().flatten()
+        #print "(",proj.fu(),", ",proj.fv(),") (",proj.cu(),", ",proj.cv(),")" #in the future, not all projection models might support these parameters
         print "Distortion:"
-        print "(",dist.p1(),", ",dist.p2(),") (",dist.k1(),", ",dist.k2(),")"
+        print dist.getParameters().flatten()
+        #print "(",dist.p1(),", ",dist.p2(),") (",dist.k1(),", ",dist.k2(),")" #not all distortion models implement these parameters

--- a/aslam_offline_calibration/kalibr/setup.py
+++ b/aslam_offline_calibration/kalibr/setup.py
@@ -13,6 +13,7 @@ setup_args = generate_distutils_setup(
     scripts=['python/kalibr_bagcreater',
              'python/kalibr_bagextractor',
              'python/kalibr_calibrate_cameras',
+             'python/kalibr_calibrate_rs_cameras',
              'python/kalibr_calibrate_imu_camera',
              'python/kalibr_camera_focus',
              'python/kalibr_camera_validator',


### PR DESCRIPTION
Minor fixes related to the camera models available for rolling shutter calibration. Also minuscule  changes to option naming and help captions. Storing the calibration results in the standard kalibr output format remains to be added.