### PR TITLE
removed line "import cv" 

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
@@ -11,7 +11,6 @@ import aslam_cv_backend as acvb
 import kalibr_common as kc
 import kalibr_camera_calibration as kcc
 
-import cv
 import cv2
 import os
 import numpy as np

--- a/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
@@ -1,4 +1,3 @@
-import cv
 import cv_bridge
 import cv2
 import rosbag


### PR DESCRIPTION
as it produced the error "no module named cv" on Ubuntu 16.04 (works perfectly without this import)
