### PR TITLE
Handle bayer_rggb8 encoding 

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
@@ -123,6 +123,8 @@ class BagImageDatasetReader(object):
             
         else:
             img_data = np.array(self.CVB.imgmsg_to_cv2(data))
+            if data.encoding is "bayer_rggb8":
+                img_data = cv2.cvtColor(img_data, cv2.cv.CV_BayerBG2BGR,3)
 
         if img_data.ndim == 3:
             img_data = cv2.cvtColor(img_data, cv2.COLOR_BGR2GRAY)

--- a/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
@@ -123,7 +123,7 @@ class BagImageDatasetReader(object):
             
         else:
             img_data = np.array(self.CVB.imgmsg_to_cv2(data))
-            if data.encoding is "bayer_rggb8":
+            if "bayer_rggb8" in data.encoding:
                 img_data = cv2.cvtColor(img_data, cv2.cv.CV_BayerBG2BGR,3)
 
         if img_data.ndim == 3:


### PR DESCRIPTION
This checks the image encoding string to see if it is bayer_rggb8 and debayers it if so.

This fixes pull request #94 which did not properly check for the encoding string. This addresses issue #83.

There are other Bayer encodings that could also be added with additional elif statements, but I don't have cameras that support those encodings to test with and I am not interested in creating synthetic data.