### PR TITLE
Make ImageDatasetReader work with 8UC1 encoded msg

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/ImageDatasetReader.py
@@ -133,8 +133,7 @@ class BagImageDatasetReader(object):
       image_16u = np.array(self.CVB.imgmsg_to_cv2(data))
       img_data = (image_16u / 256).astype("uint8")
     elif data.encoding == "8UC1" or data.encoding == "mono8":
-      img_data = np.array(self.CVB.imgmsg_to_cv2(
-          data, desired_encoding="mono8"))
+      img_data = np.array(self.CVB.imgmsg_to_cv2(data))
     elif data.encoding == "8UC3" or data.encoding == "rgb8":
       img_data = np.array(self.CVB.imgmsg_to_cv2(data))
       img_data = cv2.cvtColor(img_data, cv2.COLOR_BGR2GRAY)


### PR DESCRIPTION
Without this Kalibr errors when reading datasets where the image
encoding is "8UC1".

See https://github.com/ros-perception/vision_opencv/issues/175 for an
explanation.