### PR TITLE
Fix/python runtime warnings

### DIFF
--- a/Schweizer-Messer/sm_python/include/sm/python/unique_register_ptr_to_python.hpp
+++ b/Schweizer-Messer/sm_python/include/sm/python/unique_register_ptr_to_python.hpp
@@ -1,0 +1,26 @@
+#ifndef SM_PYTHON_UNIQUE_REGISTER_PTR_TO_PYTHON
+#define SM_PYTHON_UNIQUE_REGISTER_PTR_TO_PYTHON
+
+#include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/type_id.hpp>
+
+namespace sm {
+namespace python {
+
+// Calls register_ptr_to_python<D>() in case the class has not already been
+// registered. Related to
+// https://stackoverflow.com/questions/9888289/checking-whether-a-converter-has-already-been-registered#
+template <typename D>
+void unique_register_ptr_to_python() {
+  boost::python::type_info info = boost::python::type_id<D>(); 
+  const boost::python::converter::registration* reg = boost::python::converter::registry::query(info);
+  if (reg == NULL || reg->m_to_python == NULL) {
+    boost::python::register_ptr_to_python<D>();
+  }
+}
+
+}  // namespace python
+}  // namespace sm
+
+#endif  // SM_PYTHON_UNIQUE_REGISTER_PTR_TO_PYTHON
+

--- a/aslam_cv/aslam_cv_python/src/CameraProjections.cpp
+++ b/aslam_cv/aslam_cv_python/src/CameraProjections.cpp
@@ -7,6 +7,7 @@
 #include <aslam/cameras/RadialTangentialDistortion.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <sm/python/boost_serialization_pickle.hpp>
+#include <sm/python/unique_register_ptr_to_python.hpp>
 //#include <aslam/python/ExportDesignVariableAdapter.hpp>
 //#include <aslam/backend/DesignVariableAdapter.hpp>
 //#include <aslam/python/ExportAPrioriInformationError.hpp>
@@ -215,7 +216,7 @@ void exportGenericDistortionFunctions(T & dist) {
 
 void exportFovDistortionFunctions() {
   class_<FovDistortion, boost::shared_ptr<FovDistortion> > distortion("FovDistortion", init<>());
-  register_ptr_to_python<boost::shared_ptr<FovDistortion> >();
+  sm::python::unique_register_ptr_to_python<boost::shared_ptr<FovDistortion> >();
 
   exportGenericDistortionFunctions<FovDistortion>(distortion);
   distortion.def(init<double>(("FovDistortion(double w)")));
@@ -227,7 +228,7 @@ void exportRadialTangentialDistortionFunctions() {
   class_<RadialTangentialDistortion,
       boost::shared_ptr<RadialTangentialDistortion> > rtDistortion(
       "RadialTangentialDistortion", init<>());
-  register_ptr_to_python<boost::shared_ptr<RadialTangentialDistortion> >();
+  sm::python::unique_register_ptr_to_python<boost::shared_ptr<RadialTangentialDistortion> >();
 
   exportGenericDistortionFunctions<RadialTangentialDistortion>(rtDistortion);
 
@@ -251,7 +252,7 @@ void exportOmniProjection(std::string name) {
 
   class_<OmniProjection<D>, boost::shared_ptr<OmniProjection<D> > > omniProjection(
       name.c_str(), init<>());
-  register_ptr_to_python<boost::shared_ptr<OmniProjection<D> > >();
+  sm::python::unique_register_ptr_to_python<boost::shared_ptr<OmniProjection<D> > >();
 
   omniProjection.def(init<>((name + "(distortion_t distortion)").c_str())).def(
       init<double, double, double, double, double, int, int, D>(
@@ -295,7 +296,7 @@ void exportPinholeProjection(std::string name) {
 
   class_<PinholeProjection<D>, boost::shared_ptr<PinholeProjection<D> > > pinholeProjection(
       name.c_str(), init<>());
-  register_ptr_to_python<boost::shared_ptr<PinholeProjection<D> > >();
+  sm::python::unique_register_ptr_to_python<boost::shared_ptr<PinholeProjection<D> > >();
 
   pinholeProjection.def(init<>((name + "(distortion_t distortion)").c_str()))
       .def(
@@ -339,13 +340,13 @@ void exportCameraProjections() {
 
   class_<NoDistortion, boost::shared_ptr<NoDistortion> > noDistortion(
       "NoDistortion", init<>());
-  register_ptr_to_python<boost::shared_ptr<NoDistortion> >();
+  sm::python::unique_register_ptr_to_python<boost::shared_ptr<NoDistortion> >();
 
   exportGenericDistortionFunctions<NoDistortion>(noDistortion);
 
   class_<EquidistantDistortion, boost::shared_ptr<EquidistantDistortion> > equidistantDistortion(
       "EquidistantDistortion", init<>());
-  register_ptr_to_python<boost::shared_ptr<EquidistantDistortion> >();
+  sm::python::unique_register_ptr_to_python<boost::shared_ptr<EquidistantDistortion> >();
 
   equidistantDistortion.def(init<double, double, double, double>());
   exportGenericDistortionFunctions<EquidistantDistortion>(

--- a/aslam_cv/aslam_cv_python/src/CameraShutters.cpp
+++ b/aslam_cv/aslam_cv_python/src/CameraShutters.cpp
@@ -4,6 +4,7 @@
 #include <boost/serialization/nvp.hpp>
 #include <aslam/Time.hpp>
 #include <sm/python/boost_serialization_pickle.hpp>
+#include <sm/python/unique_register_ptr_to_python.hpp>
 
 //#include <aslam/python/ExportDesignVariableAdapter.hpp>
 
@@ -40,7 +41,7 @@ void exportGlobalShutter(std::string name) {
       name.c_str(), init<>());
   globalShutter.def(init<>((name + "()").c_str()));
 
-  register_ptr_to_python<boost::shared_ptr<GlobalShutter> >();
+  sm::python::unique_register_ptr_to_python<boost::shared_ptr<GlobalShutter> >();
 
   exportGenericShutterFunctions<GlobalShutter>(globalShutter);
 }
@@ -54,7 +55,7 @@ void exportRollingShutter(std::string name) {
       "lineDelay", &RollingShutter::lineDelay,
       "Returns the Line Delay of the Rolling Shutter");
 
-  register_ptr_to_python<boost::shared_ptr<RollingShutter> >();
+  sm::python::unique_register_ptr_to_python<boost::shared_ptr<RollingShutter> >();
 
   exportGenericShutterFunctions<RollingShutter>(rollingShutter);
 }

--- a/aslam_optimizer/aslam_backend_python/include/aslam/python/ExportDesignVariableAdapter.hpp
+++ b/aslam_optimizer/aslam_backend_python/include/aslam/python/ExportDesignVariableAdapter.hpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <aslam/backend/DesignVariable.hpp>
 #include <aslam/backend/DesignVariableAdapter.hpp>
+#include <sm/python/unique_register_ptr_to_python.hpp>
 
 
 namespace aslam {
@@ -26,7 +27,8 @@ namespace aslam {
   class_< DesignVariableAdapter<dv_t>, boost::shared_ptr<DesignVariableAdapter<dv_t> >, bases<DesignVariable> >( name.c_str(), init<boost::shared_ptr< dv_t> >() )
 	.def("value", &DesignVariableAdapter<dv_t>::valuePtr)
   ;
-  register_ptr_to_python<boost::shared_ptr<DesignVariableAdapter<dv_t> > >();
+
+  sm::python::unique_register_ptr_to_python<boost::shared_ptr<DesignVariableAdapter<dv_t> > >();
   //boost::python::implicitly_convertible<boost::shared_ptr<DesignVariableAdapter<dv_t> >, boost::shared_ptr<DesignVariable> >();
   
   }

--- a/aslam_optimizer/aslam_backend_python/include/aslam/python/ExportDesignVariableAdapter.hpp
+++ b/aslam_optimizer/aslam_backend_python/include/aslam/python/ExportDesignVariableAdapter.hpp
@@ -27,7 +27,6 @@ namespace aslam {
   class_< DesignVariableAdapter<dv_t>, boost::shared_ptr<DesignVariableAdapter<dv_t> >, bases<DesignVariable> >( name.c_str(), init<boost::shared_ptr< dv_t> >() )
 	.def("value", &DesignVariableAdapter<dv_t>::valuePtr)
   ;
-
   sm::python::unique_register_ptr_to_python<boost::shared_ptr<DesignVariableAdapter<dv_t> > >();
   //boost::python::implicitly_convertible<boost::shared_ptr<DesignVariableAdapter<dv_t> >, boost::shared_ptr<DesignVariable> >();
   


### PR DESCRIPTION
This gets rid of this type of python runtime warnings:

> RuntimeWarning: to-Python converter for boost::shared_ptr<aslam::cameras::Type> already registered; second conversion method ignored.