### PR TITLE
Added cv::waitKey(1) commands to make image visualization work again.

### DIFF
--- a/aslam_cv/aslam_cameras/src/GridCalibrationTargetCheckerboard.cpp
+++ b/aslam_cv/aslam_cameras/src/GridCalibrationTargetCheckerboard.cpp
@@ -115,6 +115,7 @@ bool GridCalibrationTargetCheckerboard::computeObservation(const cv::Mat & image
                   CV_RGB(255,0,0), 3, 8, false);
 
     cv::imshow("Checkerboard corners", imageCopy1);  // OpenCV call
+    cv::waitKey(1);
   }
 
   //exit here if there is an error

--- a/aslam_cv/aslam_cameras/src/GridCalibrationTargetCirclegrid.cpp
+++ b/aslam_cv/aslam_cameras/src/GridCalibrationTargetCirclegrid.cpp
@@ -87,6 +87,7 @@ bool GridCalibrationTargetCirclegrid::computeObservation(const cv::Mat & image,
                   CV_RGB(255,0,0), 3, 8, false);
 
     cv::imshow("Circlegrid corners", imageCopy1);  // OpenCV call
+    cv::waitKey(1);
   }
 
   //exit here if there is an error

--- a/aslam_cv/aslam_cameras/src/GridDetector.cpp
+++ b/aslam_cv/aslam_cameras/src/GridDetector.cpp
@@ -204,8 +204,11 @@ bool GridDetector::findTarget(const cv::Mat & image, const aslam::Time & stamp,
     }
 
     cv::imshow("Corner reprojection", imageCopy1);  // OpenCV call
-    if (_options.imageStepping)
-      cv::waitKey();
+    if (_options.imageStepping) {
+      cv::waitKey(0);
+    } else {
+      cv::waitKey(1);
+    }
   }
 
   return success;

--- a/aslam_cv/aslam_cameras_april/src/GridCalibrationTargetAprilgrid.cpp
+++ b/aslam_cv/aslam_cameras_april/src/GridCalibrationTargetAprilgrid.cpp
@@ -243,6 +243,7 @@ bool GridCalibrationTargetAprilgrid::computeObservation(
       }
 
     cv::imshow("Aprilgrid: Tag corners", imageCopy1);  // OpenCV call
+    cv::waitKey(1);
 
     /* copy image for modification */
     cv::Mat imageCopy2 = image.clone();
@@ -258,6 +259,7 @@ bool GridCalibrationTargetAprilgrid::computeObservation(
     }
 
     cv::imshow("Aprilgrid: Tag detection", imageCopy2);  // OpenCV call
+    cv::waitKey(1);
 
     //if success is false exit here (delayed exit if _options.showExtractionVideo=true for debugging)
     if (!success)


### PR DESCRIPTION
Ptal @schneith @mbuerki .

In general, the april grid visualization / image stepping might need some refactoring, but this is a first fix to make the april grid detection work again.