### PR TITLE
Eigen 3 Compatibility

### DIFF
--- a/aslam_nonparametric_estimation/bsplines_python/src/BSplinePython.cpp
+++ b/aslam_nonparametric_estimation/bsplines_python/src/BSplinePython.cpp
@@ -28,7 +28,9 @@ public:
 
 	}
 	double getBi(int i){
-		return biVector_.coeff(i);
+		// Note this is normally a VectorXd
+		// So dynamic rows and 1 column
+		return biVector_.coeff(i,0);
 	}
 };
 


### PR DESCRIPTION
Thought others might run into my issue.
- Using Eigen 3.3.90
- This normally causes a static coeff error
- Seems it didn't like the template
- Tested on ubuntu 16.04

Error:
```
error: static assertion failed: THIS_COEFFICIENT_ACCESSOR_TAKING_ONE_ACCESS_IS_ONLY_FOR_EXPRESSIONS_ALLOWING_LINEAR_ACCESS
     #define EIGEN_STATIC_ASSERT(X,MSG) static_assert(X,#MSG);
                                        ^
```