### PR TITLE
suitesparse to use the same compiler as the rest of targets

### DIFF
--- a/suitesparse/CMakeLists.txt
+++ b/suitesparse/CMakeLists.txt
@@ -18,6 +18,7 @@ catkin_package(
 )
 
 ExternalProject_Add(suitesparse_src
+  CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
   DOWNLOAD_COMMAND rm -f SuiteSparse-${VERSION}.tar.gz && wget http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-${VERSION}.tar.gz
   PATCH_COMMAND tar -xzf ../SuiteSparse-${VERSION}.tar.gz && rm -rf ../suitesparse_src-build/SuiteSparse && sed -i.bu "s/\\/usr\\/local\\/lib/..\\/lib/g" SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk && sed -i.bu "s/\\/usr\\/local\\/include/..\\/include/g" SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk && mv SuiteSparse ../suitesparse_src-build/
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
When downloading and installing suitesparse from `http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-${VERSION}.tar.gz` the C/C++ compiler option set by `catkin_make` is not delegated, thus a different compiler may be used.

Problem arises, for example, when the default CMake compiler is clang but just for catkin_make I want to set it to gcc/g++. In this case, suitesparse would still use clang anyway.