### PR TITLE
Update matplotlib import statement in SW

### DIFF
--- a/Schweizer-Messer/sm_python/python/sm/PlotCollection.py
+++ b/Schweizer-Messer/sm_python/python/sm/PlotCollection.py
@@ -5,7 +5,7 @@ import wx
 import wx.aui
 import matplotlib as mpl
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as Canvas
-from matplotlib.backends.backend_wxagg import NavigationToolbar2Wx as Toolbar
+from matplotlib.backends.backend_wx import NavigationToolbar2Wx as Toolbar
 import collections
 
 class PlotCollection:


### PR DESCRIPTION
Changing from matplotlib.backends.backend_wxagg to from matplotlib.backends.backend_wx. kalibr_calibrate_cameras would not run unless this line was changed.