### PR TITLE
Fix compilation with Boost 1.67

### DIFF
--- a/Schweizer-Messer/python_module/cmake/add_python_export_library.cmake
+++ b/Schweizer-Messer/python_module/cmake/add_python_export_library.cmake
@@ -67,9 +67,26 @@ ${SETUP_PY_TEXT}
   INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_DIRS})
 
   if(APPLE)
-    SET(BOOST_COMPONENTS python system)
+    SET(BOOST_COMPONENTS system)
   else()
-    SET(BOOST_COMPONENTS python)
+    SET(BOOST_COMPONENTS)
+  endif()
+  if(PYTHONLIBS_VERSION_STRING VERSION_LESS 3)
+    find_package(Boost QUIET)
+    if(Boost_VERSION LESS 106700)
+      list(APPEND BOOST_COMPONENTS python)
+    else()
+      # The boost_python library has been renamed in Boost 1.67 and the FindBoost.cmake
+      # module requires a Python version suffix:
+      #
+      # References:
+      # - https://www.boost.org/docs/libs/1_67_0/libs/python/doc/html/rn.html
+      # - https://cmake.org/cmake/help/v3.12/module/FindBoost.html
+      #
+      list(APPEND BOOST_COMPONENTS python27)
+    endif()
+  else()
+    list(APPEND BOOST_COMPONENTS python3)
   endif()
   find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS}) 
 


### PR DESCRIPTION
The boost_python library has been renamed in Boost 1.67 and the
FindBoost.cmake module requires a Python version suffix:

References:
- https://www.boost.org/docs/libs/1_67_0/libs/python/doc/html/rn.html
- https://cmake.org/cmake/help/v3.12/module/FindBoost.html

Fix taken from:
https://github.com/ros-perception/image_common/pull/85

Without this, on macos where homebrew already updated to 1.67,
compilation otherwise fails with an error like

    Unable to find the requested Boost libraries.

    Boost version: 1.67.0

    Boost include path: /usr/local/include

    Could not find the following Boost libraries:

            boost_python

    Some (but not all) of the required Boost libraries were found.  You may
    need to install these additional Boost libraries.  Alternatively, set
    BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT
    to the location of Boost.

The same patch probably applies `numpy_eigen` upstream.