### PR TITLE
Fix optimization for none distortion when compiled with default flags #236

### DIFF
--- a/aslam_optimizer/aslam_backend/src/Optimizer2.cpp
+++ b/aslam_optimizer/aslam_backend/src/Optimizer2.cpp
@@ -296,7 +296,8 @@ namespace aslam {
                     const int dbd = d->minimalDimensions();
                     Eigen::VectorXd dxS = _dx.segment(startIdx, dbd);
                     dxS *= d->scaling();
-                    d->update(&dxS[0], dbd);
+                    if(dbd > 0)
+                        d->update(&dxS[0], dbd);
                     startIdx += dbd;
                 }
                 // Track the maximum delta


### PR DESCRIPTION
When compiled with default cmake flags the `none` distortion causes Eigen assertion #236. This fixes the issue. (When compiled in Release configuration everything worked fine even without this patch. Looks like compiler optimizes out that part of the code.)