### PR TITLE
Fixed - RS calibration logic

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_rs_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_rs_cameras
@@ -12,7 +12,6 @@ import kalibr_common as kc
 import kalibr_camera_calibration as kcc
 import kalibr_rs_camera_calibration as rscc
 
-import cv
 import cv2
 import os
 import numpy as np


### PR DESCRIPTION
Hello, and thanks again for continually maintaining this project. Recently we have been trying to calibration a rolling shutter camera and have worked on getting the Kalibr implementation working. There are a few issues with the provided scripts which I have addressed in this PR.

- Removed old opencv import
- Fixed out of date log statement causing crash
- Changed execution permission (so it shows up in rosrun now)
- Fixed design problem creation

The main issue is that the original problem (to my understanding, I could be interpreting the code wrong) assumed that the calibration target was in *full* view during every frame of the dataset. The main problem is that the original implementation does not leverage the feature IDs, so if one frame does not observe a feature, the entire feature array will be "offset" and thus error terms will be in respect to the wrong keypoints. Is this correct? (cc @othlu).

I have addressed this by using a simple dictionary that is used to lookup the correct landmark expression using the IDs. The program runs for our rolling shutter and gives reasonably small values (but non-zero) for our camera. As we don't have any groundtruth to compare against I can vouch if this actually is correctly solving the optimization problem. I can't make a pull request to the wiki, but I think some details on the rolling shutter calibration would help (see #135 #102 #134 #74). Here are the steps that we used to do the rolling shutter calibration:

1. Start with the entire target in view (we used the default [Aprilgrid 6x6 0.8x0.8m](https://github.com/ethz-asl/kalibr/wiki/downloads#calibration-targets))
2. Use a high framerate with low exposure time (we used 30hz with as low of an exposure as possible)
3. Keeping the camera still, we moved the calibration grid very quickly in front of the camera making sure to "skew" the board so that intrinsics are able to calibrate.
4. We just ran the script with the default values as follows:
```
rosrun kalibr kalibr_calibrate_rs_cameras \
--model pinhole-equi-rs --target april_6x6_80x80cm.yaml \
--topic /camera/left --bag dataset_rs.bag \
--inverse-feature-variance 1 --frame-rate 30 
```
5. The script should run and will also do a knot refinement that takes a pretty long time



