### PR TITLE
Remove importing PIL not compatible with sensor messages

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_bagcreater
+++ b/aslam_offline_calibration/kalibr/python/kalibr_bagcreater
@@ -5,7 +5,6 @@ import rosbag
 import rospy
 from sensor_msgs.msg import Image
 from sensor_msgs.msg import Imu
-import ImageFile
 import time, sys, os
 import argparse
 import cv2


### PR DESCRIPTION
Not needed. And "from PIL import Image" compatible with Ubuntu 18.04 conflicts with "from sensor_msgs.msg import Image"