### PR TITLE
Fixed azimuthal/azumithal typos and gave better control to the user o…

### DIFF
--- a/aslam_cv/aslam_cameras/src/GridCalibrationTargetCheckerboard.cpp
+++ b/aslam_cv/aslam_cameras/src/GridCalibrationTargetCheckerboard.cpp
@@ -50,7 +50,8 @@ GridCalibrationTargetCheckerboard::GridCalibrationTargetCheckerboard(
 void GridCalibrationTargetCheckerboard::initialize()
 {
   if (_options.showExtractionVideo) {
-    cv::namedWindow("Checkerboard corners", CV_WINDOW_AUTOSIZE);
+    cv::namedWindow("Checkerboard corners", CV_WINDOW_NORMAL);
+    cv::resizeWindow("Checkerboard corners",1280,960);
     cvStartWindowThread();
   }
 }

--- a/aslam_cv/aslam_cameras/src/GridDetector.cpp
+++ b/aslam_cv/aslam_cameras/src/GridDetector.cpp
@@ -32,7 +32,8 @@ GridDetector::GridDetector(boost::shared_ptr<CameraGeometryBase> geometry,
 void GridDetector::initializeDetector()
 {
   if (_options.plotCornerReprojection) {
-    cv::namedWindow("Corner reprojection");
+    cv::namedWindow("Corner reprojection",cv::WINDOW_NORMAL);
+    cv::resizeWindow("Corner reprojection", 1280, 960);
     cvStartWindowThread();
   }
 }

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
@@ -457,7 +457,7 @@ def plotAzumithalError(cself, cam_id, fno=1, clearFigure=True, stats=None, noSho
     if stats is None:
         stats = getAllPointStatistics(cself, cam_id)
     angleError = np.array([ [ np.degrees(s.azumithalAngle), math.sqrt(s.squaredError)] for s in stats ])
-    # sort by azumithal angle
+    # sort by azimuthal angle
     sae = angleError[ angleError[:,0].argsort() ]
     # Now plot
     f = pl.figure(fno)
@@ -468,12 +468,12 @@ def plotAzumithalError(cself, cam_id, fno=1, clearFigure=True, stats=None, noSho
     pl.subplot(121)
     pl.plot(sae[:,0],sae[:,1],'bx-')
     pl.grid('on')
-    pl.xlabel('azumithal angle (deg)')
+    pl.xlabel('azimuthal angle (deg)')
     pl.ylabel('reprojection error (pixels)')
     pl.subplot(122)
     pl.hist(sae[:,0])
     pl.grid('on')
-    pl.xlabel('azumithal angle (deg)')
+    pl.xlabel('azimuthal angle (deg)')
     pl.ylabel('count')
     if not noShow:
         pl.show()
@@ -768,7 +768,7 @@ def generateReport(cself, filename="report.pdf", showOnScreen=True, graph=None, 
         plotter.add_figure(title, f)
         figs.append(f)
         f = pl.figure(cidx*10+2)
-        title="cam{0}: azimutal error".format(cidx)
+        title="cam{0}: azimuthal error".format(cidx)
         plotAzumithalError(cself, cidx, fno=f.number, noShow=True, title=title)
         plotter.add_figure(title, f)
         figs.append(f)


### PR DESCRIPTION
Changed the windows mode from cv::WINDOW_AUTOSIZE to cv::WINDOW_NORMAL and gave a default size of 1280x960. This way big images do not overfill the screen and can be resized by the user. 

Fixed several typos on azimuthal/azumithal/azimutal words.