### PR TITLE
camera_validator: Fix thread getting stuck (empty windows)

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
@@ -100,7 +100,7 @@ class CameraChainValidator(object):
             edge["A"][cidx_dest] = self.prepareStereoRectificationMaps(cidx_src, cidx_dest)
                 
         #register the callback for the synchronized images
-        sync_sub = message_filters.TimeSynchronizer([val.image_sub for val in self.monovalidators],1)
+        sync_sub = message_filters.ApproximateTimeSynchronizer([val.image_sub for val in self.monovalidators], 10, 0.02)
         sync_sub.registerCallback(self.synchronizedCallback)
 
         #initialize message throttler

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
@@ -192,7 +192,7 @@ class CameraChainValidator(object):
     def generatePairView(self, camAnr, camBnr):
         #prepare the window
         windowName = "Rectified view (cam{0} and cam{1})".format(camAnr, camBnr)
-        cv2.namedWindow(windowName, 1)
+        cv2.namedWindow(windowName, cv2.WINDOW_AUTOSIZE)
             
         #get the mono validators for each cam
         camA = self.monovalidators[camAnr]
@@ -378,7 +378,6 @@ class MonoCameraValidator(object):
         
         self.topic = camConfig.getRosTopic()
         self.windowName = "Camera: {0}".format(self.topic)
-        cv2.namedWindow(self.windowName, 1)
     
         #register the cam topic to the message synchronizer
         self.image_sub = message_filters.Subscriber(self.topic, Image)
@@ -400,6 +399,7 @@ class MonoCameraValidator(object):
         
     
     def generateMonoview(self, np_image, observation, obs_valid):
+        cv2.namedWindow(self.windowName, cv2.WINDOW_AUTOSIZE)
         np_image = cv2.cvtColor(np_image, cv2.COLOR_GRAY2BGR)
 
         if obs_valid:

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
@@ -120,7 +120,7 @@ class CameraChainValidator(object):
           
             #convert image to numpy
             try:
-                if (msg.encoding == "rgb8"):
+                if (msg.encoding == "rgb8" or msg.encoding == "bgra8"):
                   cv_image = np.squeeze(np.array(self.bridge.imgmsg_to_cv2(msg, "mono8")))
                 else:
                   cv_image = self.bridge.imgmsg_to_cv2(msg)

--- a/aslam_offline_calibration/kalibr/python/kalibr_visualize_distortion
+++ b/aslam_offline_calibration/kalibr/python/kalibr_visualize_distortion
@@ -94,8 +94,8 @@ def distort(image, distortion_model, distortion_coeffs, focal_lengths,
             distortion_coeffs)
         distorted = denormalize(distorted_normalized, focal_lengths, 
             principal_point)
-        if (int(distorted[0]) < 0 or int(distorted[0]) > image.shape[0] or
-            int(distorted[1]) < 0 or int(distorted[1]) > image.shape[1]):
+        if (int(distorted[0]) < 0 or int(distorted[0]) >= image.shape[0] or
+            int(distorted[1]) < 0 or int(distorted[1]) >= image.shape[1]):
           continue
         distorted_image[int(distorted[0]), int(distorted[1])] = image[i,j]
     return distorted_image


### PR DESCRIPTION
Moved the creation of the cv2.namedWindow from the MonoCameraValidator constructor to the callback function. Otherwise, this caused the following error:

    QObject::startTimer: Timers cannot be started from another thread

... with the result that the image windows remained black and the node became stuck.

Other changes:

* Add support for bgra8 encoding
* Use ApproximateTimeSynchronizer

Fixes #201 .

This PR includes a cleaned-up version of #275 , so once this is merged, #275 can be closed.