### PR TITLE
macos support

### DIFF
--- a/Schweizer-Messer/numpy_eigen/CMakeLists.txt
+++ b/Schweizer-Messer/numpy_eigen/CMakeLists.txt
@@ -22,6 +22,7 @@ add_definitions(-std=c++0x -D__STRICT_ANSI__)
 include_directories(include ${Boost_INCLUDE_DIRS})
 
 IF(APPLE)
+include_directories(include /usr/local/lib/python2.7/site-packages/numpy/core/include ${Boost_INCLUDE_DIRS})  
   link_directories( /usr/local/lib )
 ENDIF(APPLE)
 

--- a/Schweizer-Messer/sm_python/CMakeLists.txt
+++ b/Schweizer-Messer/sm_python/CMakeLists.txt
@@ -8,8 +8,9 @@ find_package(catkin REQUIRED COMPONENTS cmake_modules sm_common numpy_eigen sm_k
                                         sm_property_tree python_module)
 include_directories(${catkin_INCLUDE_DIRS})
 find_package(Eigen REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
 
-include_directories(include ${Eigen_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(include ${Eigen_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 
 catkin_package(

--- a/Schweizer-Messer/sm_random/CMakeLists.txt
+++ b/Schweizer-Messer/sm_random/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 project(sm_random)
 
 find_package(catkin REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
+
 include_directories(${catkin_INCLUDE_DIRS})
 
 catkin_package(
@@ -11,7 +13,7 @@ catkin_package(
   DEPENDS
 )
 
-include_directories(include)
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 ##############
 ## Building ##

--- a/aslam_cv/aslam_cameras/CMakeLists.txt
+++ b/aslam_cv/aslam_cameras/CMakeLists.txt
@@ -8,6 +8,13 @@ catkin_simple()
 ADD_DEFINITIONS(-DASLAM_USE_ROS )
 
 find_package(Boost REQUIRED COMPONENTS system serialization filesystem)
+find_package(OpenCV REQUIRED)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+)
 
 #common commands for building c++ executables and libraries
 cs_add_library(${PROJECT_NAME} 

--- a/aslam_cv/aslam_cameras_april/CMakeLists.txt
+++ b/aslam_cv/aslam_cameras_april/CMakeLists.txt
@@ -5,9 +5,10 @@ find_package(catkin_simple REQUIRED)
 catkin_simple()
 
 find_package(OpenCV REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
 
 ADD_DEFINITIONS(-DASLAM_USE_ROS )
-include_directories(${Eigen_INCLUDE_DIRS})
+include_directories(${Eigen_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 
 cs_add_library(${PROJECT_NAME} 

--- a/aslam_cv/aslam_cv_backend/CMakeLists.txt
+++ b/aslam_cv/aslam_cv_backend/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(Boost REQUIRED COMPONENTS system)
 
 catkin_simple()
 
+include_directories(${Boost_INCLUDE_DIRS})
+
 cs_add_library(${PROJECT_NAME}
   src/GridCalibrationTargetDesignVariableContainer.cpp
   # src/CameraGeometryDesignVariableContainer.cpp

--- a/aslam_cv/aslam_cv_backend_python/CMakeLists.txt
+++ b/aslam_cv/aslam_cv_backend_python/CMakeLists.txt
@@ -5,6 +5,9 @@ find_package(catkin_simple REQUIRED)
 
 catkin_simple()
 
+find_package(Boost REQUIRED COMPONENTS serialization) 
+include_directories(${Boost_INCLUDE_DIRS})
+
 add_python_export_library(${PROJECT_NAME} python/aslam_cv_backend
   src/module.cpp  
   src/GridCalibration.cpp

--- a/aslam_cv/aslam_cv_python/CMakeLists.txt
+++ b/aslam_cv/aslam_cv_python/CMakeLists.txt
@@ -10,6 +10,10 @@ if(APPLE)
   add_definitions( -ftemplate-depth-1024)
 endif()
 
+find_package(Boost REQUIRED COMPONENTS serialization) 
+include_directories(${Boost_INCLUDE_DIRS})
+
+
 add_python_export_library(${PROJECT_NAME} python/aslam_cv
   src/module.cpp
   src/CameraGeometries.cpp
@@ -36,7 +40,7 @@ add_python_export_library(${PROJECT_NAME} python/aslam_cv
   src/PinholeUndistorter.cpp
 )
 
-find_package(Boost REQUIRED COMPONENTS serialization) 
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
+
 cs_install()
 cs_export()

--- a/aslam_cv/aslam_cv_serialization/CMakeLists.txt
+++ b/aslam_cv/aslam_cv_serialization/CMakeLists.txt
@@ -18,6 +18,12 @@ cs_add_library(${PROJECT_NAME}
 find_package(Boost REQUIRED COMPONENTS serialization system)
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
 
+include_directories(
+	include
+	${catkin_INCLUDE_DIRS}
+	${Boost_INCLUDE_DIRS}
+)
+
 # Avoid clash with tr1::tuple: https://code.google.com/p/googletest/source/browse/trunk/README?r=589#257
 #add_definitions(-DGTEST_USE_OWN_TR1_TUPLE=0)
 #catkin_add_gtest(${PROJECT_NAME}_tests

--- a/aslam_cv/aslam_imgproc/CMakeLists.txt
+++ b/aslam_cv/aslam_imgproc/CMakeLists.txt
@@ -7,7 +7,7 @@ catkin_simple()
 
 find_package(Boost REQUIRED COMPONENTS system)
 
-include_directories(${Eigen_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS})
 cs_add_library(${PROJECT_NAME} src/UndistorterBase.cpp)
 
 

--- a/aslam_cv/aslam_time/CMakeLists.txt
+++ b/aslam_cv/aslam_time/CMakeLists.txt
@@ -4,7 +4,14 @@ project(aslam_time)
 find_package(catkin_simple REQUIRED)
 catkin_simple()
 
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED COMPONENTS serialization system)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+)
+
 
 cs_add_library(${PROJECT_NAME}
     src/time.cpp

--- a/aslam_incremental_calibration/incremental_calibration/CMakeLists.txt
+++ b/aslam_incremental_calibration/incremental_calibration/CMakeLists.txt
@@ -12,6 +12,9 @@ else()
   set(CMAKE_CXX_FLAGS "-std=c++0x")
 endif()
 
+find_package(Boost REQUIRED COMPONENTS system thread)
+include_directories(${Boost_INCLUDE_DIRS})
+
 cs_add_library(${PROJECT_NAME}
   src/base/Serializable.cpp
   src/base/Timestamp.cpp
@@ -40,7 +43,6 @@ cs_add_library(${PROJECT_NAME}
   src/algorithms/linalg.cpp
 )
 
-find_package(Boost REQUIRED COMPONENTS system thread)
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${TBB_LIBRARIES})
 
 if(CATKIN_ENABLE_TESTING)

--- a/aslam_incremental_calibration/incremental_calibration_python/CMakeLists.txt
+++ b/aslam_incremental_calibration/incremental_calibration_python/CMakeLists.txt
@@ -4,6 +4,9 @@ project(incremental_calibration_python)
 find_package(catkin_simple REQUIRED)
 catkin_simple()
 
+find_package(Boost REQUIRED COMPONENTS system)
+include_directories(${Boost_INCLUDE_DIRS})
+
 if(APPLE)
 
 else()

--- a/aslam_nonparametric_estimation/aslam_splines/CMakeLists.txt
+++ b/aslam_nonparametric_estimation/aslam_splines/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin_simple REQUIRED)
 catkin_simple()
 
 find_package(Boost REQUIRED COMPONENTS system )
-
+include_directories(${Boost_INCLUDE_DIRS})
 
 cs_add_library(${PROJECT_NAME}
   src/BSplinePoseDesignVariable.cpp

--- a/aslam_nonparametric_estimation/aslam_splines_python/CMakeLists.txt
+++ b/aslam_nonparametric_estimation/aslam_splines_python/CMakeLists.txt
@@ -4,6 +4,9 @@ project(aslam_splines_python)
 find_package(catkin_simple REQUIRED)
 catkin_simple()
 
+find_package(Boost REQUIRED COMPONENTS serialization) 
+include_directories(${Boost_INCLUDE_DIRS})
+
 add_python_export_library(${PROJECT_NAME} python/aslam_splines
   src/spline_module.cpp
   src/BSplineMotionError.cpp

--- a/aslam_nonparametric_estimation/bsplines/CMakeLists.txt
+++ b/aslam_nonparametric_estimation/bsplines/CMakeLists.txt
@@ -3,7 +3,11 @@ project(bsplines)
 
 find_package(catkin_simple REQUIRED)
 
+find_package(Boost REQUIRED COMPONENTS system)
+
 catkin_simple()
+
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 cs_add_library(${PROJECT_NAME} 
   src/BSpline.cpp

--- a/aslam_nonparametric_estimation/bsplines_python/CMakeLists.txt
+++ b/aslam_nonparametric_estimation/bsplines_python/CMakeLists.txt
@@ -4,6 +4,9 @@ project(bsplines_python)
 find_package(catkin_simple REQUIRED)
 catkin_simple()
 
+find_package(Boost REQUIRED COMPONENTS system)
+include_directories(${Boost_INCLUDE_DIRS})
+
 # Set up the python exports.
 SET(PY_PROJECT_NAME bsplines_python)
 SET(PY_PACKAGE_DIR python/bsplines)

--- a/aslam_offline_calibration/kalibr/CMakeLists.txt
+++ b/aslam_offline_calibration/kalibr/CMakeLists.txt
@@ -4,6 +4,9 @@ project(kalibr)
 find_package(catkin_simple REQUIRED)
 catkin_simple()
 
+find_package(Boost REQUIRED COMPONENTS serialization) 
+include_directories(${Boost_INCLUDE_DIRS})
+
 ##################################
 # error terms (+python export)
 ##################################

--- a/aslam_optimizer/aslam_backend/CMakeLists.txt
+++ b/aslam_optimizer/aslam_backend/CMakeLists.txt
@@ -6,7 +6,7 @@ catkin_simple()
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
-include_directories(${Eigen_INCLUDE_DIRS})
+include_directories(${Eigen_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 #add_definitions( -fPIC -msse2 -mssse3 -march=nocona -Wextra -Winit-self -Woverloaded-virtual -Wnon-virtual-dtor -Wsign-promo -Wno-long-long -std=c++0x -O3)
 

--- a/aslam_optimizer/aslam_backend_expressions/CMakeLists.txt
+++ b/aslam_optimizer/aslam_backend_expressions/CMakeLists.txt
@@ -9,9 +9,9 @@ find_package(catkin_simple REQUIRED)
 
 catkin_simple()
 
-include_directories(${EIGEN_INCLUDE_DIRS})
-
 find_package(Boost REQUIRED COMPONENTS system)
+
+include_directories(${EIGEN_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 cs_add_library(${PROJECT_NAME}
   src/RotationExpression.cpp

--- a/aslam_optimizer/aslam_backend_python/CMakeLists.txt
+++ b/aslam_optimizer/aslam_backend_python/CMakeLists.txt
@@ -4,6 +4,9 @@ project(aslam_backend_python)
 find_package(catkin_simple REQUIRED)
 catkin_simple()
 
+find_package(Boost REQUIRED COMPONENTS system)
+include_directories(${Boost_INCLUDE_DIRS})
+
 add_definitions( -fPIC -Wextra -Winit-self -Woverloaded-virtual -Wnon-virtual-dtor -Wsign-promo -Wno-long-long -std=c++0x)
 
 # This functions take TARGET_NAME PYTHON_MODULE_DIRECTORY sourceFile1 [sourceFile2 ...]

--- a/aslam_optimizer/sparse_block_matrix/CMakeLists.txt
+++ b/aslam_optimizer/sparse_block_matrix/CMakeLists.txt
@@ -7,8 +7,10 @@ project(sparse_block_matrix)
 find_package(catkin_simple REQUIRED)
 catkin_simple()
 
+find_package(Boost REQUIRED COMPONENTS system)
+
 find_package(Eigen3)
-include_directories(${Eigen_INCLUDE_DIRS})
+include_directories(${Eigen_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 cs_add_library(${PROJECT_NAME} 
   src/matrix_structure.cpp


### PR DESCRIPTION
Mostly involves adding in boost and eigen includes to the various CMakeLists.txt. Perhaps there is a better way to do this using catkin_simple. It still builds fine in Ubuntu 16.04.