### PR TITLE
Add validity check to focal guess

### DIFF
--- a/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
+++ b/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
@@ -774,7 +774,8 @@ bool PinholeProjection<DISTORTION_T>::initializeIntrinsics(const std::vector<Gri
           continue;
 
          double f_guess = cv::norm(ipts.at(0) - ipts.at(1)) / M_PI;
-         f_guesses.push_back(f_guess);
+         if(std::isfinite(f_guess))
+            f_guesses.push_back(f_guess);
       }
     }
   }


### PR DESCRIPTION
`f_guess` can sometimes be `nan` skipping the manual focal guess input (`f_guesses` isn't empty) and resulting in a failed calibration. This fix check if the focal guess is a valid number