### PR TITLE
Adhesion check disabled for cam==1 / Fixes Error "cameras not connected through mutual observations."

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
@@ -84,8 +84,14 @@ class MulticamCalibrationGraph(object):
 #############################################################    
     #check if all cams are connected through observations
     def isGraphConnected(self):
-        #check if all vertices are connected
-        return self.G.adhesion()
+
+        if self.numCams == 1:
+            # Since igaph 0.8, adhesion correctly returns 0 for the non-connected one cam case.
+            #   which evaluates to false later on. So we skip the check and return true in the one camera case.
+            return True
+        else:
+            #check if all vertices are connected
+            return self.G.adhesion()
         
     #returns the list of cam_ids that share common view with the specified cam_id
     def getCamOverlaps(self, cam_id):

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
@@ -88,7 +88,7 @@ class MulticamCalibrationGraph(object):
             # Since igaph 0.8, adhesion returns 0 instead of -2147483648 for a graph with a single vertex.
             # As 0 evaluates to False later in the process, kalibr exits with the cameras unconnected error.
             # Todo / Future work: Figure out if we should use is_connected instead of adhesion. 
-	    #                     See discussion in PR #358 / https://github.com/ethz-asl/kalibr/pull/358
+            #                     See discussion in PR #358 / https://github.com/ethz-asl/kalibr/pull/358
             return True
         else:
             #check if all vertices are connected

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
@@ -84,7 +84,6 @@ class MulticamCalibrationGraph(object):
 #############################################################    
     #check if all cams are connected through observations
     def isGraphConnected(self):
-
         if self.numCams == 1:
             # Since igaph 0.8, adhesion correctly returns 0 for the non-connected one cam case.
             #   which evaluates to false later on. So we skip the check and return true in the one camera case.

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
@@ -85,8 +85,10 @@ class MulticamCalibrationGraph(object):
     #check if all cams are connected through observations
     def isGraphConnected(self):
         if self.numCams == 1:
-            # Since igaph 0.8, adhesion correctly returns 0 for the non-connected one cam case.
-            #   which evaluates to false later on. So we skip the check and return true in the one camera case.
+            # Since igaph 0.8, adhesion returns 0 instead of -2147483648 for a graph with a single vertex.
+            # As 0 evaluates to False later in the process, kalibr exits with the cameras unconnected error.
+            # Todo / Future work: Figure out if we should use is_connected instead of adhesion. 
+	    #                     See discussion in PR #358 / https://github.com/ethz-asl/kalibr/pull/358
             return True
         else:
             #check if all vertices are connected


### PR DESCRIPTION
**Problem**
On newer ubuntu systems, `kalibr_calibrate_cameras` fails to calibrate single camera systems with the error:
`Cameras are not connected through mutual observations, please check the dataset. Maybe adjust the approx. sync. tolerance.`

**Affected systems:**
- Ubuntu 18.04.4 LTS with igraph 0.8 

**Underlying Reason**
The Function `isGraphConnected` in MulticamGraph.py checks for the graph adhesion (https://igraph.org/c/doc/igraph-Flows.html#igraph_adhesion).
For older versions, this returned -2147483648 (signed 32 int minimum) in the unconnected case, which magically made the code using  `isGraphConnected` happy (as it evaluates differently than 0) and kalibr progressed.
In igaph0.8 this correctly returns 0. Now this evaluates to False and kalibr complains.

Note the difference:
```
>>> -2147483648 == True
False
>>> -2147483648 == False
False
>>> 
```

versus

```
>>> 0 == True
False
>>> 0 == False
True
```



**Fix**
Adhesion check is omitted for the one camera case and isGraphConnected returns True.


