### PR TITLE
fixes for Ubuntu 20.04

### DIFF
--- a/Schweizer-Messer/numpy_eigen/CMakeLists.txt
+++ b/Schweizer-Messer/numpy_eigen/CMakeLists.txt
@@ -19,6 +19,9 @@ catkin_package(
 )
 add_definitions(-std=c++0x -D__STRICT_ANSI__)
 
+# ignore "error: return-statement with a value, in function returning ‘void’" in "__multiarray_api.h"
+add_compile_options(-fpermissive)
+
 include_directories(include ${Boost_INCLUDE_DIRS})
 
 IF(APPLE)

--- a/Schweizer-Messer/numpy_eigen/include/numpy_eigen/type_traits.hpp
+++ b/Schweizer-Messer/numpy_eigen/include/numpy_eigen/type_traits.hpp
@@ -46,7 +46,7 @@ template<> struct TypeToNumPy<unsigned char>
   static const char * typeString() { return "unsigned char"; }
   static bool canConvert(int type)
   {
-    return type == NPY_UBYTE || type == NPY_BYTE || type == NPY_CHAR;
+    return type == NPY_UBYTE || type == NPY_BYTE || type == NPY_STRING;
   }
 };
 
@@ -57,7 +57,7 @@ template<> struct TypeToNumPy<char>
   static const char * typeString() { return "char"; }
   static bool canConvert(int type)
   {
-    return type == NPY_UBYTE || type == NPY_BYTE || type == NPY_CHAR;
+    return type == NPY_UBYTE || type == NPY_BYTE || type == NPY_STRING;
   }
 };
 
@@ -136,8 +136,6 @@ inline const char * npyTypeToString(int npyType)
       return "NPY_NTYPES";
     case NPY_NOTYPE:
       return "NPY_NOTYPE";
-    case NPY_CHAR:
-      return "NPY_CHAR";
     default:
       return "Unknown type";
     }

--- a/Schweizer-Messer/python_module/cmake/add_python_export_library.cmake
+++ b/Schweizer-Messer/python_module/cmake/add_python_export_library.cmake
@@ -86,7 +86,7 @@ ${SETUP_PY_TEXT}
       list(APPEND BOOST_COMPONENTS python27)
     endif()
   else()
-    list(APPEND BOOST_COMPONENTS python3)
+    list(APPEND BOOST_COMPONENTS python38)
   endif()
   find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS}) 
 

--- a/Schweizer-Messer/sm_python/include/sm/python/Id.hpp
+++ b/Schweizer-Messer/sm_python/include/sm/python/Id.hpp
@@ -20,7 +20,7 @@ namespace sm { namespace python {
 
       // The "Convert from C to Python" API
       static PyObject * convert(id_t const & id){
-	PyObject * i = PyInt_FromLong(id.getId());
+	PyObject * i = PyLong_FromLong(id.getId());
     // It seems that the call to "incref(.)" caused a memory leak!
     // I will check this in hoping it doesn't cause any instability.
 	return i;//boost::python::incref(i);
@@ -30,7 +30,7 @@ namespace sm { namespace python {
       // Two functions: convertible() and construct()
       static void * convertible(PyObject* obj_ptr)
       {
-          if (!(PyInt_Check(obj_ptr) || PyLong_Check(obj_ptr)))
+          if (!(PyLong_Check(obj_ptr) || PyLong_Check(obj_ptr)))
               return 0;
           
           return obj_ptr;
@@ -43,8 +43,8 @@ namespace sm { namespace python {
 
 	// Get the value.
           boost::uint64_t value;
-          if ( PyInt_Check(obj_ptr) ) {
-              value = PyInt_AsUnsignedLongLongMask(obj_ptr);
+          if ( PyLong_Check(obj_ptr) ) {
+              value = PyLong_AsUnsignedLongLongMask(obj_ptr);
           } else {
               value = PyLong_AsUnsignedLongLong(obj_ptr);
           }

--- a/aslam_cv/aslam_cameras/src/GridCalibrationTargetCheckerboard.cpp
+++ b/aslam_cv/aslam_cameras/src/GridCalibrationTargetCheckerboard.cpp
@@ -50,8 +50,8 @@ GridCalibrationTargetCheckerboard::GridCalibrationTargetCheckerboard(
 void GridCalibrationTargetCheckerboard::initialize()
 {
   if (_options.showExtractionVideo) {
-    cv::namedWindow("Checkerboard corners", CV_WINDOW_AUTOSIZE);
-    cvStartWindowThread();
+    cv::namedWindow("Checkerboard corners", cv::WINDOW_AUTOSIZE);
+    cv::startWindowThread();
   }
 }
 
@@ -97,21 +97,21 @@ bool GridCalibrationTargetCheckerboard::computeObservation(const cv::Mat & image
   if (_options.doSubpixelRefinement && success) {
     cv::cornerSubPix(
         image, centers, cv::Size(_options.windowWidth, _options.windowWidth), cv::Size(-1, -1),
-        cv::TermCriteria(CV_TERMCRIT_EPS + CV_TERMCRIT_ITER, 30, 0.1));
+        cv::TermCriteria(cv::TermCriteria::Type::EPS + cv::TermCriteria::Type::MAX_ITER, 30, 0.1));
   }
 
   //draw corners
   if (_options.showExtractionVideo) {
     //image with refined (blue) and raw corners (red)
     cv::Mat imageCopy1 = image.clone();
-    cv::cvtColor(imageCopy1, imageCopy1, CV_GRAY2RGB);
+    cv::cvtColor(imageCopy1, imageCopy1, cv::COLOR_GRAY2RGB);
     cv::drawChessboardCorners(imageCopy1, cv::Size(rows(), cols()), centers,
                               true);
 
     // write error msg
     if (!success)
       cv::putText(imageCopy1, "Detection failed! (frame not used)",
-                  cv::Point(50, 50), CV_FONT_HERSHEY_SIMPLEX, 0.8,
+                  cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
                   CV_RGB(255,0,0), 3, 8, false);
 
     cv::imshow("Checkerboard corners", imageCopy1);  // OpenCV call

--- a/aslam_cv/aslam_cameras/src/GridCalibrationTargetCirclegrid.cpp
+++ b/aslam_cv/aslam_cameras/src/GridCalibrationTargetCirclegrid.cpp
@@ -30,8 +30,8 @@ GridCalibrationTargetCirclegrid::GridCalibrationTargetCirclegrid(size_t rows, si
 void GridCalibrationTargetCirclegrid::initialize()
 {
   if (_options.showExtractionVideo) {
-    cv::namedWindow("Circlegrid corners", CV_WINDOW_AUTOSIZE);
-    cvStartWindowThread();
+    cv::namedWindow("Circlegrid corners", cv::WINDOW_AUTOSIZE);
+    cv::startWindowThread();
   }
 }
 
@@ -77,13 +77,13 @@ bool GridCalibrationTargetCirclegrid::computeObservation(const cv::Mat & image,
   if (_options.showExtractionVideo) {
     //image with refined (blue) and raw corners (red)
     cv::Mat imageCopy1 = image.clone();
-    cv::cvtColor(imageCopy1, imageCopy1, CV_GRAY2RGB);
+    cv::cvtColor(imageCopy1, imageCopy1, cv::COLOR_GRAY2RGB);
     cv::drawChessboardCorners(imageCopy1, cv::Size(rows(), cols()), centers, true);
 
     // write error msg
     if (!success)
       cv::putText(imageCopy1, "Detection failed! (frame not used)",
-                  cv::Point(50, 50), CV_FONT_HERSHEY_SIMPLEX, 0.8,
+                  cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
                   CV_RGB(255,0,0), 3, 8, false);
 
     cv::imshow("Circlegrid corners", imageCopy1);  // OpenCV call

--- a/aslam_cv/aslam_cameras/src/GridDetector.cpp
+++ b/aslam_cv/aslam_cameras/src/GridDetector.cpp
@@ -185,7 +185,7 @@ bool GridDetector::findTarget(const cv::Mat & image, const aslam::Time & stamp,
   // show plot of reprojected corners
   if (_options.plotCornerReprojection) {
     cv::Mat imageCopy1 = image.clone();
-    cv::cvtColor(imageCopy1, imageCopy1, CV_GRAY2RGB);
+    cv::cvtColor(imageCopy1, imageCopy1, cv::COLOR_GRAY2RGB);
 
     if (success) {
       //calculate reprojection
@@ -198,7 +198,7 @@ bool GridDetector::findTarget(const cv::Mat & image, const aslam::Time & stamp,
 
     } else {
       cv::putText(imageCopy1, "Detection failed! (frame not used)",
-                  cv::Point(50, 50), CV_FONT_HERSHEY_SIMPLEX, 0.8,
+                  cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
                   CV_RGB(255,0,0), 3, 8, false);
     }
 

--- a/aslam_cv/aslam_cameras/src/ImageMask.cpp
+++ b/aslam_cv/aslam_cameras/src/ImageMask.cpp
@@ -19,7 +19,7 @@ ImageMask::ImageMask(const sm::PropertyTree & config)
   // Note: if this fails, _mask.data == NULL.
   // http://opencv.willowgarage.com/documentation/cpp/reading_and_writing_images_and_video.html#cv-imread
   // \todo Better error handling.
-  _mask = cv::imread(maskFile, CV_LOAD_IMAGE_GRAYSCALE);
+  _mask = cv::imread(maskFile, cv::IMREAD_GRAYSCALE);
   //TODO: BB: How to implement scale here?
 }
 

--- a/aslam_cv/aslam_cameras_april/src/GridCalibrationTargetAprilgrid.cpp
+++ b/aslam_cv/aslam_cameras_april/src/GridCalibrationTargetAprilgrid.cpp
@@ -164,10 +164,10 @@ bool GridCalibrationTargetAprilgrid::computeObservation(
         //show the duplicate tags in the image
         cv::destroyAllWindows();
         cv::namedWindow("Wild Apriltag detected. Hide them!");
-        cvStartWindowThread();
+        cv::startWindowThread();
 
         cv::Mat imageCopy = image.clone();
-        cv::cvtColor(imageCopy, imageCopy, CV_GRAY2RGB);
+        cv::cvtColor(imageCopy, imageCopy, cv::COLOR_GRAY2RGB);
 
         //mark all duplicate tags in image
         for (int j = 0; i < detections.size() - 1; i++) {
@@ -178,10 +178,10 @@ bool GridCalibrationTargetAprilgrid::computeObservation(
         }
 
         cv::putText(imageCopy, "Duplicate Apriltags detected. Hide them.",
-                    cv::Point(50, 50), CV_FONT_HERSHEY_SIMPLEX, 0.8,
+                    cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
                     CV_RGB(255,0,0), 2, 8, false);
         cv::putText(imageCopy, "Press enter to exit...", cv::Point(50, 80),
-                    CV_FONT_HERSHEY_SIMPLEX, 0.8, CV_RGB(255,0,0), 2, 8, false);
+                    cv::FONT_HERSHEY_SIMPLEX, 0.8, CV_RGB(255,0,0), 2, 8, false);
         cv::imshow("Duplicate Apriltags detected. Hide them", imageCopy);  // OpenCV call
 
         // and exit
@@ -217,12 +217,12 @@ bool GridCalibrationTargetAprilgrid::computeObservation(
   if (_options.doSubpixRefinement && success)
     cv::cornerSubPix(
         image, tagCorners, cv::Size(2, 2), cv::Size(-1, -1),
-        cv::TermCriteria(CV_TERMCRIT_EPS + CV_TERMCRIT_ITER, 30, 0.1));
+        cv::TermCriteria(cv::TermCriteria::Type::EPS + cv::TermCriteria::Type::MAX_ITER, 30, 0.1));
 
   if (_options.showExtractionVideo) {
     //image with refined (blue) and raw corners (red)
     cv::Mat imageCopy1 = image.clone();
-    cv::cvtColor(imageCopy1, imageCopy1, CV_GRAY2RGB);
+    cv::cvtColor(imageCopy1, imageCopy1, cv::COLOR_GRAY2RGB);
     for (unsigned i = 0; i < detections.size(); i++)
       for (unsigned j = 0; j < 4; j++) {
         //raw apriltag corners
@@ -237,7 +237,7 @@ bool GridCalibrationTargetAprilgrid::computeObservation(
 
         if (!success)
           cv::putText(imageCopy1, "Detection failed! (frame not used)",
-                      cv::Point(50, 50), CV_FONT_HERSHEY_SIMPLEX, 0.8,
+                      cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
                       CV_RGB(255,0,0), 3, 8, false);
       }
 
@@ -246,14 +246,14 @@ bool GridCalibrationTargetAprilgrid::computeObservation(
 
     /* copy image for modification */
     cv::Mat imageCopy2 = image.clone();
-    cv::cvtColor(imageCopy2, imageCopy2, CV_GRAY2RGB);
+    cv::cvtColor(imageCopy2, imageCopy2, cv::COLOR_GRAY2RGB);
     /* highlight detected tags in image */
     for (unsigned i = 0; i < detections.size(); i++) {
       detections[i].draw(imageCopy2);
 
       if (!success)
         cv::putText(imageCopy2, "Detection failed! (frame not used)",
-                    cv::Point(50, 50), CV_FONT_HERSHEY_SIMPLEX, 0.8,
+                    cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
                     CV_RGB(255,0,0), 3, 8, false);
     }
 

--- a/aslam_cv/aslam_imgproc/include/aslam/implementation/aslamcv_helper.hpp
+++ b/aslam_cv/aslam_imgproc/include/aslam/implementation/aslamcv_helper.hpp
@@ -20,12 +20,11 @@ using namespace cv;
 ///
 template<typename CAMERA_T>
 static void icvGetRectangles(boost::shared_ptr<CAMERA_T> camera_geometry,
-                             CvSize imgSize, cv::Rect_<float>& inner,
+                             cv::Size imgSize, cv::Rect_<float>& inner,
                              cv::Rect_<float>& outer) {
   const int N = 9;
   int x, y, k;
-  cv::Ptr<CvMat> _pts(cvCreateMat(1, N * N, CV_32FC2));
-  CvPoint2D32f* pts = (CvPoint2D32f*) (_pts->data.ptr);
+  std::vector<cv::Point2f> _pts(N*N);
 
   for (y = k = 0; y < N; y++) {
     for (x = 0; x < N; x++) {
@@ -43,7 +42,7 @@ static void icvGetRectangles(boost::shared_ptr<CAMERA_T> camera_geometry,
       //undistort
       camera_geometry->projection().distortion().undistort(point);
 
-      pts[k++] = cvPoint2D32f((float) point[0], (float) point[1]);
+      _pts[k++] = cv::Point2f((float) point[0], (float) point[1]);
     }
   }
 
@@ -53,7 +52,7 @@ static void icvGetRectangles(boost::shared_ptr<CAMERA_T> camera_geometry,
   // the code will likely not work with extreme rotation matrices (R) (>45%)
   for (y = k = 0; y < N; y++)
     for (x = 0; x < N; x++) {
-      CvPoint2D32f p = pts[k++];
+      cv::Point2f p = _pts[k++];
       oX0 = MIN(oX0, p.x);
       oX1 = MAX(oX1, p.x);
       oY0 = MIN(oY0, p.y);
@@ -85,8 +84,8 @@ static void icvGetRectangles(boost::shared_ptr<CAMERA_T> camera_geometry,
 ///
 template<typename CAMERA_T>
 Eigen::Matrix3d getOptimalNewCameraMatrix(
-    boost::shared_ptr<CAMERA_T> camera_geometry, CvSize imgSize, double alpha,
-    CvSize newImgSize) {
+    boost::shared_ptr<CAMERA_T> camera_geometry, cv::Size imgSize, double alpha,
+    cv::Size newImgSize) {
 
   cv::Rect_<float> inner, outer;
   newImgSize = newImgSize.width * newImgSize.height != 0 ? newImgSize : imgSize;

--- a/aslam_incremental_calibration/incremental_calibration/src/base/Thread.cpp
+++ b/aslam_incremental_calibration/incremental_calibration/src/base/Thread.cpp
@@ -24,6 +24,7 @@
 #include "aslam/calibration/exceptions/SystemException.h"
 #include "aslam/calibration/exceptions/InvalidOperationException.h"
 
+namespace aslam {
 #ifdef __NR_gettid
 static pid_t gettid (void) {
   return syscall(__NR_gettid);
@@ -33,6 +34,7 @@ static pid_t gettid (void) {
   return -ENOSYS;
 }
 #endif
+}
 
 namespace aslam {
   namespace calibration {

--- a/aslam_offline_calibration/ethz_apriltag2/src/example/apriltags_demo.cpp
+++ b/aslam_offline_calibration/ethz_apriltag2/src/example/apriltags_demo.cpp
@@ -294,7 +294,7 @@ public:
       v4l2_set_control(device, V4L2_CID_BRIGHTNESS, m_brightness*256);
     }
     v4l2_close(device);
-#endif 
+#endif
 
     // find and open a USB camera (built in laptop camera, web cam etc)
     m_cap = cv::VideoCapture(m_deviceId);
@@ -302,12 +302,12 @@ public:
       cerr << "ERROR: Can't find video device " << m_deviceId << "\n";
       exit(1);
     }
-    m_cap.set(CV_CAP_PROP_FRAME_WIDTH, m_width);
-    m_cap.set(CV_CAP_PROP_FRAME_HEIGHT, m_height);
+    m_cap.set(cv::CAP_PROP_FRAME_WIDTH, m_width);
+    m_cap.set(cv::CAP_PROP_FRAME_HEIGHT, m_height);
     cout << "Camera successfully opened (ignore error messages above...)" << endl;
     cout << "Actual resolution: "
-         << m_cap.get(CV_CAP_PROP_FRAME_WIDTH) << "x"
-         << m_cap.get(CV_CAP_PROP_FRAME_HEIGHT) << endl;
+         << m_cap.get(cv::CAP_PROP_FRAME_WIDTH) << "x"
+         << m_cap.get(cv::CAP_PROP_FRAME_HEIGHT) << endl;
 
     // prepare window for drawing the camera images
     if (m_draw) {
@@ -380,7 +380,7 @@ public:
       //      m_cap.retrieve(image);
 
       // detect April tags (requires a gray scale image)
-      cv::cvtColor(image, image_gray, CV_BGR2GRAY);
+      cv::cvtColor(image, image_gray, cv::COLOR_BGR2GRAY);
       vector<AprilTags::TagDetection> detections = m_tagDetector->extractTags(image_gray);
 
       // print out each detection


### PR DESCRIPTION
This PR incorporates a couple of fixes in an attempt to compile for Ubuntu 20.04:
- port to OpenCV 4
- replace deprecated API
- other compilation fixes

The issue of using Eigen in boost-python (https://github.com/ethz-asl/kalibr/issues/396, https://github.com/ethz-asl/kalibr/issues/404) remains. `kalibr` will not fully compile until this has been resolved, but this PR resolves other issues and should be compatible with previous versions.