### PR TITLE
Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ros:melodic-ros-core
+
+RUN apt-get update && apt-get install -y python-setuptools \
+  python-rosinstall ipython libeigen3-dev libboost-all-dev \
+  doxygen libopencv-dev ros-melodic-vision-opencv \
+  ros-melodic-image-transport-plugins ros-melodic-cmake-modules \
+  software-properties-common wget \
+  libpoco-dev python-matplotlib python-scipy python-git \
+  python-pip ipython libtbb-dev libblas-dev liblapack-dev \
+  python-catkin-tools libv4l-dev python-catkin-tools python-wxversion python-wxtools python-igraph
+
+RUN mkdir -p /root/workspace/src
+WORKDIR /root/workspace
+RUN git clone https://github.com/ethz-asl/kalibr /root/workspace/src/kalibr
+RUN catkin init && catkin config --extend /opt/ros/melodic/ --merge-devel -DCMAKE_BUILD_TYPE=Release -j4 && catkin build
+
+WORKDIR /root/data/
+
+ENTRYPOINT bash -c "source /root/workspace/devel/setup.bash && /bin/bash"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,23 @@ RUN apt-get update && apt-get install -y python-setuptools \
   software-properties-common wget \
   libpoco-dev python-matplotlib python-scipy python-git \
   python-pip ipython libtbb-dev libblas-dev liblapack-dev \
-  python-catkin-tools libv4l-dev python-catkin-tools python-wxversion python-wxtools python-igraph
+  python-catkin-tools libv4l-dev python-catkin-tools python-wxversion \
+  python-wxtools python-igraph libcairo2-dev
+
+# Dependencies for glvnd and X11.
+RUN apt-get update \
+  && apt-get install -y -qq --no-install-recommends \
+    libglvnd0 \
+    libgl1 \
+    libglx0 \
+    libegl1 \
+    libxext6 \
+    libx11-6 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Env vars for the nvidia-container-runtime.
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES graphics,utility,compute
 
 RUN mkdir -p /root/workspace/src
 WORKDIR /root/workspace

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#########
+# Usage #
+#########
+# Build the container by running docker build -t kalibr .
+# Run using ./run_docker.sh <path-to-data-directory>
+# This will open an interactive bash shell inside the container
+# with the built Kalibr workspace sourced.
+#
+# The path given will be mounted inside the container at /root/data
+# You can use that to mount the directory containing your calibration bag file
+# inside the container.
+
+data_dir=$1
+if [ ! -d "$data_dir" ]; then
+  echo "data directory does not exist: $data_dir"
+  exit 1
+fi
+
+docker run -it -v $data_dir:/root/data kalibr
+

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -18,5 +18,8 @@ if [ ! -d "$data_dir" ]; then
   exit 1
 fi
 
-docker run -it -v $data_dir:/root/data kalibr
+
+xhost +local:root;
+nvidia-docker run -it -e DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix:rw --privileged -v $data_dir:/root/data kalibr
+xhost -local:root;
 


### PR DESCRIPTION
Added a simple Docker configuration. This allows people on other than the supported operating systems and ros versions to still run it. 

We could also build and publish the image on the docker registry, which would allow people to run Kalibr without having to build it.

Hopefully, this would make the project more future proof.

If you think this should be merged, I'm happy to write the documentation for how to use it on the wiki.