### PR TITLE
    debug camera validator.

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
@@ -378,7 +378,6 @@ class MonoCameraValidator(object):
         
         self.topic = camConfig.getRosTopic()
         self.windowName = "Camera: {0}".format(self.topic)
-        cv2.namedWindow(self.windowName, 1)
     
         #register the cam topic to the message synchronizer
         self.image_sub = message_filters.Subscriber(self.topic, Image)


### PR DESCRIPTION
It didn't work kalibr_camera_validator originally.
I tested and confirmed it displays left, right, and combined rectified image on docker.
