### PR TITLE
Fix multi-imu calibration T_i_b transform

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_imu_camera
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_imu_camera
@@ -146,18 +146,18 @@ def main():
         sys.exit(2)
     
     imus = list()
-    for (imu_yaml, imu_model) in zip(parsed.imu_yamls, parsed.imu_models):
+    for i, (imu_yaml, imu_model) in enumerate(zip(parsed.imu_yamls, parsed.imu_models)):
         imuConfig = kc.ImuParameters(imu_yaml)
         imuConfig.printDetails()
         if imu_model == 'calibrated':
             imus.append( sens.IccImu(imuConfig, parsed, isReferenceImu=(not imus), \
-                         estimateTimedelay=parsed.estimate_imu_delay) )
+                         estimateTimedelay=parsed.estimate_imu_delay, imuNr=i) )
         elif imu_model == 'scale-misalignment':
             imus.append( sens.IccScaledMisalignedImu(imuConfig, parsed, isReferenceImu=(not imus), \
-                         estimateTimedelay=parsed.estimate_imu_delay) )
+                         estimateTimedelay=parsed.estimate_imu_delay, imuNr=i) )
         elif imu_model == 'scale-misalignment-size-effect':
             imus.append( sens.IccScaledMisalignedSizeEffectImu(imuConfig, parsed, isReferenceImu=(not imus), \
-                         estimateTimedelay=parsed.estimate_imu_delay) )
+                         estimateTimedelay=parsed.estimate_imu_delay, imuNr=i) )
         else:
             sm.logError("Model {0} is currently unsupported.".format(imu_model))
             sys.exit(2)

--- a/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
@@ -576,8 +576,7 @@ class IccImu(object):
         return self.imuConfig
 
     def updateImuConfig(self):
-        self.imuConfig.setImuPose(sm.Transformation(sm.r2quat(self.q_i_b_Dv.toRotationMatrix()), \
-                                                    self.r_b_Dv.toEuclidean()).T())
+        self.imuConfig.setImuPose(self.getTransformationFromBodyToImu())
         self.imuConfig.setTimeOffset(self.timeOffset)
 
     def __init__(self, imuConfig, parsed, isReferenceImu=True, estimateTimedelay=True):

--- a/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
@@ -550,10 +550,11 @@ class IccCameraChain():
 class IccImu(object):
     
     class ImuParameters(kc.ImuParameters):
-        def __init__(self, imuConfig):
+        def __init__(self, imuConfig, imuNr):
             kc.ImuParameters.__init__(self, '', True)
             self.data = imuConfig.data
             self.data["model"] = "calibrated"
+            self.imuNr = imuNr
 
         def setImuPose(self, T_i_b):
             self.data["T_i_b"] = T_i_b.tolist()
@@ -567,7 +568,7 @@ class IccImu(object):
         def printDetails(self, dest=sys.stdout):
             print("  Model: {0}".format(self.data["model"]), file=dest)
             kc.ImuParameters.printDetails(self, dest)
-            print("  T_i_b (body to imu)", file=dest)
+            print("  T_ib (imu0 to imu{0})".format(self.imuNr), file=dest)
             print(self.formatIndented("    ", np.array(self.data["T_i_b"])), file=dest)
             print("  time offset with respect to IMU0: {0} [s]".format(self.data["time_offset"]), file=dest)
 
@@ -579,14 +580,14 @@ class IccImu(object):
         self.imuConfig.setImuPose(self.getTransformationFromBodyToImu().T())
         self.imuConfig.setTimeOffset(self.timeOffset)
 
-    def __init__(self, imuConfig, parsed, isReferenceImu=True, estimateTimedelay=True):
+    def __init__(self, imuConfig, parsed, isReferenceImu=True, estimateTimedelay=True, imuNr=0):
 
         #determine whether IMU coincides with body frame (for multi-IMU setups)
         self.isReferenceImu = isReferenceImu
         self.estimateTimedelay = estimateTimedelay
 
         #store input
-        self.imuConfig = self.ImuParameters(imuConfig)
+        self.imuConfig = self.ImuParameters(imuConfig, imuNr)
 
         #load dataset
         self.dataset = initImuBagDataset(parsed.bagfile[0], imuConfig.getRosTopic(), \
@@ -911,8 +912,8 @@ class IccImu(object):
 class IccScaledMisalignedImu(IccImu):
 
     class ImuParameters(IccImu.ImuParameters):
-        def __init__(self, imuConfig):
-            IccImu.ImuParameters.__init__(self, imuConfig)
+        def __init__(self, imuConfig, imuNr):
+            IccImu.ImuParameters.__init__(self, imuConfig, imuNr)
             self.data = imuConfig.data
             self.data["model"] = "scale-misalignment"
 
@@ -1063,8 +1064,8 @@ class IccScaledMisalignedImu(IccImu):
 class IccScaledMisalignedSizeEffectImu(IccScaledMisalignedImu):
 
     class ImuParameters(IccScaledMisalignedImu.ImuParameters):
-        def __init__(self, imuConfig):
-            IccScaledMisalignedImu.ImuParameters.__init__(self, imuConfig)
+        def __init__(self, imuConfig, imuNr):
+            IccScaledMisalignedImu.ImuParameters.__init__(self, imuConfig, imuNr)
             self.data = imuConfig.data
             self.data["model"] = "scale-misalignment-size-effect"
 

--- a/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
@@ -576,7 +576,7 @@ class IccImu(object):
         return self.imuConfig
 
     def updateImuConfig(self):
-        self.imuConfig.setImuPose(self.getTransformationFromBodyToImu())
+        self.imuConfig.setImuPose(self.getTransformationFromBodyToImu().T())
         self.imuConfig.setTimeOffset(self.timeOffset)
 
     def __init__(self, imuConfig, parsed, isReferenceImu=True, estimateTimedelay=True):

--- a/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
@@ -567,7 +567,7 @@ class IccImu(object):
         def printDetails(self, dest=sys.stdout):
             print("  Model: {0}".format(self.data["model"]), file=dest)
             kc.ImuParameters.printDetails(self, dest)
-            print("  T_i_b", file=dest)
+            print("  T_i_b (body to imu)", file=dest)
             print(self.formatIndented("    ", np.array(self.data["T_i_b"])), file=dest)
             print("  time offset with respect to IMU0: {0} [s]".format(self.data["time_offset"]), file=dest)
 

--- a/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
@@ -776,8 +776,8 @@ class IccImu(object):
         if self.isReferenceImu:
             return sm.Transformation()
         return sm.Transformation(sm.r2quat(self.q_i_b_Dv.toRotationMatrix()) , \
-                                 np.dot(self.q_i_b_Dv.toRotationMatrix(), \
-                                        self.r_b_Dv.toEuclidean()))
+                                 - np.dot(self.q_i_b_Dv.toRotationMatrix(), \
+                                          self.r_b_Dv.toEuclidean()))
 
     def findOrientationPrior(self, referenceImu):
         print("")


### PR DESCRIPTION
Assuming the bug described in #488 is valid, and that the function [getTransformationFromBodyToImu](https://github.com/ethz-asl/kalibr/blob/master/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py#L775) is correct, this should address the issue.

This also adds the string `body to imu` to the output. This is still not the most helpful description for multi-imu-calibration, so updates would be welcome. 