### PR TITLE
Bag filter for desired camera frequency

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
@@ -23,10 +23,10 @@ import signal
 
 np.set_printoptions(suppress=True)
 
-def initBagDataset(bagfile, topic, from_to):
+def initBagDataset(bagfile, topic, from_to, freq):
     print("\tDataset:          {0}".format(bagfile))
     print("\tTopic:            {0}".format(topic))
-    reader = kc.BagImageDatasetReader(bagfile, topic, bag_from_to=from_to)
+    reader = kc.BagImageDatasetReader(bagfile, topic, bag_from_to=from_to, bag_freq=freq)
     print("\tNumber of images: {0}".format(reader.numImages()))
     return reader
 
@@ -85,7 +85,8 @@ def parseArgs():
     groupSource.add_argument('--bag', dest='bagfile', help='The bag file with the data')
     groupSource.add_argument('--topics', nargs='+', dest='topics', help='The list of image topics', required=True)
     groupSource.add_argument('--bag-from-to', metavar='bag_from_to', type=float, nargs=2, help='Use the bag data starting from up to this time [s]')
-    
+    groupSource.add_argument('--bag-freq', metavar='bag_freq', type=float, help='Frequency to extract features at [hz]')
+
     groupTarget = parser.add_argument_group('Calibration target configuration')
     groupTarget.add_argument('--target', dest='targetYaml', help='Calibration target configuration as yaml file', required=True)
     
@@ -166,7 +167,7 @@ def main():
 
         if modelName in cameraModels:
             #open dataset 
-            dataset = initBagDataset(parsed.bagfile, topic, parsed.bag_from_to)
+            dataset = initBagDataset(parsed.bagfile, topic, parsed.bag_from_to, parsed.bag_freq)
         
             #create camera
             cameraModel = cameraModels[modelName]

--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_imu_camera
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_imu_camera
@@ -69,6 +69,7 @@ def parseArgs():
     groupData = parser.add_argument_group('Dataset source')
     groupData.add_argument('--bag', dest='bagfile', nargs=1, help='Ros bag file containing image and imu data (rostopics specified in the yamls)', action=Once, required=True)
     groupData.add_argument('--bag-from-to', metavar='bag_from_to', type=float, nargs=2, help='Use the bag data starting from up to this time [s]')
+    groupData.add_argument('--bag-freq', metavar='bag_freq', type=float, help='Frequency to extract features at [hz]')
     groupData.add_argument('--perform-synchronization',  action='store_true', dest='perform_synchronization', \
                           help='Perform a clock synchronization according to \'Clock synchronization algorithms for network measurements\' by Zhang et al. (2002).')
     

--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_rs_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_rs_cameras
@@ -23,10 +23,10 @@ import signal
 
 np.set_printoptions(suppress=True)
 
-def __initBagDataset(bagfile, topic, from_to):
+def __initBagDataset(bagfile, topic, from_to, freq):
     print("\tDataset:          {0}".format(bagfile))
     print("\tTopic:            {0}".format(topic))
-    reader = kc.BagImageDatasetReader(bagfile, topic, bag_from_to=from_to)
+    reader = kc.BagImageDatasetReader(bagfile, topic, bag_from_to=from_to, bag_freq=freq)
     print("\tNumber of images: {0}".format(reader.numImages()))
     return reader
 
@@ -90,6 +90,7 @@ def __parseArgs():
     groupSource.add_argument('--bag', dest='bagfile', help='The bag file with the data.')
     groupSource.add_argument('--topic', dest='topic', help='The image topic.', required=True)
     groupSource.add_argument('--bag-from-to', metavar='bag_from_to', type=float, nargs=2, help='Use the bag data starting from up to this time [s].')
+    groupSource.add_argument('--bag-freq', metavar='bag_freq', type=float, help='Frequency to extract features at [hz]')
 
     groupTarget = parser.add_argument_group('Calibration target configuration')
     groupTarget.add_argument('--target', dest='targetYaml', help='Calibration target configuration as yaml file.', required=True)
@@ -135,7 +136,7 @@ def main():
     ######
     ## load bagfile and extract targets:
     targetConfig = kc.CalibrationTargetParameters(parsed.targetYaml)
-    dataset = __initBagDataset(parsed.bagfile, parsed.topic, parsed.bag_from_to)
+    dataset = __initBagDataset(parsed.bagfile, parsed.topic, parsed.bag_from_to, parsed.bag_freq)
 
     #create camera
     cameraModel = cameraModels[parsed.model]

--- a/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
@@ -18,11 +18,11 @@ import pylab as pl
 import scipy.optimize
 
 
-def initCameraBagDataset(bagfile, topic, from_to=None, perform_synchronization=False):
+def initCameraBagDataset(bagfile, topic, from_to, freq, perform_synchronization):
     print("Initializing camera rosbag dataset reader:")
     print("\tDataset:          {0}".format(bagfile))
     print("\tTopic:            {0}".format(topic))
-    reader = kc.BagImageDatasetReader(bagfile, topic, bag_from_to=from_to, \
+    reader = kc.BagImageDatasetReader(bagfile, topic, bag_from_to=from_to, bag_freq=freq, \
                                       perform_synchronization=perform_synchronization)
     print("\tNumber of images: {0}".format(len(reader.index)))
     return reader
@@ -420,7 +420,7 @@ class IccCameraChain():
         for camNr in range(0, chainConfig.numCameras()):
             camConfig = chainConfig.getCameraParameters(camNr)
             dataset = initCameraBagDataset(parsed.bagfile[0], camConfig.getRosTopic(), \
-                                           parsed.bag_from_to, parsed.perform_synchronization)
+                                           parsed.bag_from_to, parsed.bag_freq, parsed.perform_synchronization)
             
             #create the camera
             self.camList.append( IccCamera( camConfig, 


### PR DESCRIPTION
Adds support for filtering images to a lower frequency.
Can be useful to do camera calibration at a lower rate instead of changing the driver.

Example:
```
rosrun kalibr kalibr_calibrate_cameras \
    --target april_6x6.yaml --models pinhole-radtan \
    --topics /cam0/image_raw --bag cam_april.bag \
    --bag-from-to 0 100 --bag-freq 10.0
```