### PR TITLE
Fix docker entrypoint to always set environment

### DIFF
--- a/Dockerfile_ros1_16_04
+++ b/Dockerfile_ros1_16_04
@@ -31,26 +31,6 @@ ADD . $WORKSPACE/src/kalibr
 RUN	cd $WORKSPACE &&\
 	catkin build -j$(nproc)
 
+ADD docker_entrypoint.bash /docker_entrypoint.sh
 
-# When a user runs a command we will run this code before theirs
-# This will allow for using the manual focal length if it fails to init
-# https://github.com/ethz-asl/kalibr/pull/346
-ENTRYPOINT export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1 && \
-	# /bin/bash -c "source \"$WORKSPACE/devel/setup.bash\"" && \ 
-	cd $WORKSPACE && \
-	/bin/bash
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+ENTRYPOINT /docker_entrypoint.sh /bin/bash

--- a/Dockerfile_ros1_18_04
+++ b/Dockerfile_ros1_18_04
@@ -31,20 +31,6 @@ ADD . $WORKSPACE/src/kalibr
 RUN	cd $WORKSPACE &&\
 	catkin build -j$(nproc)
 
+ADD docker_entrypoint.bash /docker_entrypoint.sh
 
-# When a user runs a command we will run this code before theirs
-# This will allow for using the manual focal length if it fails to init
-# https://github.com/ethz-asl/kalibr/pull/346
-ENTRYPOINT export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1 && \
-	# /bin/bash -c "source \"$WORKSPACE/devel/setup.bash\"" && \ 
-	cd $WORKSPACE && \
-	/bin/bash
-
-
-
-
-
-
-
-
-
+ENTRYPOINT /docker_entrypoint.sh /bin/bash

--- a/Dockerfile_ros1_20_04
+++ b/Dockerfile_ros1_20_04
@@ -40,7 +40,6 @@ ENTRYPOINT export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1 && \
 	cd $WORKSPACE && \
 	/bin/bash
 
+ADD docker_entrypoint.bash /docker_entrypoint.sh
 
-
-
-
+ENTRYPOINT /docker_entrypoint.sh /bin/bash

--- a/docker_entrypoint.bash
+++ b/docker_entrypoint.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# When a user runs a command we will run this code before theirs
+# This will allow for using the manual focal length if it fails to init
+# https://github.com/ethz-asl/kalibr/pull/346
+export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1
+source $WORKSPACE/devel/setup.bash
+export PATH=$WORKSPACE/build/kalibr/catkin_generated/installspace:$PATH
+exec "$@"


### PR DESCRIPTION
Current Dockerfiles propose incorrect environment setup. The second `/bin/bash` call in chain does not inherit environment from the first one. Proposed patch fixes issue with `devel/setup.bash` and adds `kalibr_xxx` tools to PATH.