### PR TITLE
Fix matplotlib expects ints not floats

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
@@ -729,8 +729,8 @@ def plotOutlierCorners(cself, removedOutlierCorners, fno=1, clearFigure=True, ti
         corners=np.array(corners)
         
         #plot
-        subplot_rows = np.ceil( np.sqrt(len(cself.cameras)) )
-        subplot_cols = np.ceil( np.sqrt(len(cself.cameras)) )
+        subplot_rows = int(np.ceil( np.sqrt(len(cself.cameras)) ))
+        subplot_cols = int(np.ceil( np.sqrt(len(cself.cameras)) ))
         pl.subplot(subplot_rows, subplot_cols, cidx+1)
         pl.title("cam{0}".format(cidx))
             


### PR DESCRIPTION
I ran into this exception when running `kalibr_calibrate_cameras` with two cameras. Perhaps it's due to a change in numpy's casting behavior. Anyhow, the result of `np.ceil(np.sqrt(2))` is a float on my system and matplot lib does not like that.

```
Results written to file: oakd-calibration/oakd_calibration-camchain.yaml
  Detailed results written to file: oakd-calibration/oakd_calibration-results-cam.txt
Traceback (most recent call last):
  File "/home/brawner/workspace/flx_bot/catkin_ws/devel/lib/kalibr/kalibr_calibrate_cameras", line 15, in <module>
    exec(compile(fh.read(), python_script, 'exec'), context)
  File "/home/brawner/workspace/flx_bot/catkin_ws/src/kalibr/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras", line 450, in <module>
    main()
  File "/home/brawner/workspace/flx_bot/catkin_ws/src/kalibr/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras", line 424, in main
    kcc.generateReport(calibrator, reportFile, showOnScreen=not parsed.dontShowReport, graph=G, removedOutlierCorners=removedOutlierCorners);
  File "/home/brawner/workspace/flx_bot/catkin_ws/src/kalibr/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py", line 790, in generateReport
    plotOutlierCorners(cself, removedOutlierCorners, fno=f.number, title=title)
  File "/home/brawner/workspace/flx_bot/catkin_ws/src/kalibr/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py", line 734, in plotOutlierCorners
    pl.subplot(subplot_rows, subplot_cols, cidx+1)
  File "/home/brawner/.local/lib/python3.8/site-packages/matplotlib/pyplot.py", line 1289, in subplot
    key = SubplotSpec._from_subplot_args(fig, args)
  File "/home/brawner/.local/lib/python3.8/site-packages/matplotlib/gridspec.py", line 597, in _from_subplot_args
    gs = GridSpec._check_gridspec_exists(figure, rows, cols)
  File "/home/brawner/.local/lib/python3.8/site-packages/matplotlib/gridspec.py", line 225, in _check_gridspec_exists
    return GridSpec(nrows, ncols, figure=figure)
  File "/home/brawner/.local/lib/python3.8/site-packages/matplotlib/gridspec.py", line 385, in __init__
    super().__init__(nrows, ncols,
  File "/home/brawner/.local/lib/python3.8/site-packages/matplotlib/gridspec.py", line 49, in __init__
    raise ValueError(
ValueError: Number of rows must be a positive integer, not 2.0
```