### PR TITLE
Fix/docker16 18

### DIFF
--- a/Dockerfile_ros1_16_04
+++ b/Dockerfile_ros1_16_04
@@ -11,9 +11,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
 	libeigen3-dev libboost-all-dev libsuitesparse-dev \
 	doxygen \
 	libopencv-dev \
-	libpoco-dev libtbb-dev libblas-dev liblapack-dev libv4l-dev \
-	python-catkin-tools
+	libpoco-dev libtbb-dev libblas-dev liblapack-dev libv4l-dev
 
+# Install unauthenticated packages
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+	apt-get install -y --allow-unauthenticated	python-catkin-tools
 
 # Create the workspace and build kalibr in it
 ENV WORKSPACE /catkin_ws

--- a/Dockerfile_ros1_18_04
+++ b/Dockerfile_ros1_18_04
@@ -1,5 +1,7 @@
 FROM osrf/ros:melodic-desktop-full
 
+# Add expired GPG key
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
 
 # Dependencies we use, catkin tools is very good build system
 # https://github.com/ethz-asl/kalibr/wiki/installation
@@ -11,9 +13,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
 	libeigen3-dev libboost-all-dev libsuitesparse-dev \
 	doxygen \
 	libopencv-dev \
-	libpoco-dev libtbb-dev libblas-dev liblapack-dev libv4l-dev \
-	python-catkin-tools
+	libpoco-dev libtbb-dev libblas-dev liblapack-dev libv4l-dev
 
+# Install unauthenticated packages
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+	apt-get install -y --allow-unauthenticated	python-catkin-tools
 
 # Create the workspace and build kalibr in it
 ENV WORKSPACE /catkin_ws


### PR DESCRIPTION
The `python-catkin-tools` is not authenticated in the older versions of ROS (16 & 18) and must be installed with `--allow-unauthenticated`.

Further more, in Ubuntu 18, one of the ROS packages seems to have an expired GPG key, thus it has to be added manually.