### PR TITLE
fix kalibr_calibrate_cameras app for a single camera.

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
@@ -201,7 +201,7 @@ def main():
     #initialize the calibration graph
     graph = kcc.MulticamCalibrationGraph(obsdb)
     
-    if not graph.isGraphConnected():
+    if not graph.isGraphConnected() and len(cameraList)>1:
         obsdb.printTable()
         print("Cameras are not connected through mutual observations, please check the dataset. Maybe adjust the approx. sync. tolerance.")
         graph.plotGraph()


### PR DESCRIPTION
fix the kalibr_calibrate_cameras app for a single camera. Otherwise, the kalibr stops for lack of overlap between cameras