### PR TITLE
Make the ENTRYPOINT  source actually work

### DIFF
--- a/Dockerfile_ros1_16_04
+++ b/Dockerfile_ros1_16_04
@@ -37,13 +37,10 @@ RUN	cd $WORKSPACE &&\
 # When a user runs a command we will run this code before theirs
 # This will allow for using the manual focal length if it fails to init
 # https://github.com/ethz-asl/kalibr/pull/346
-ENTRYPOINT export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1 && \
-	# /bin/bash -c "source \"$WORKSPACE/devel/setup.bash\"" && \ 
-	cd $WORKSPACE && \
-	/bin/bash
+RUN echo "export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1" >> /root/.bashrc && \
+    echo 'source "$WORKSPACE/devel/setup.bash"' >> /root/.bashrc
 
-
-
+ENTRYPOINT ["/bin/bash"]
 
 
 

--- a/Dockerfile_ros1_18_04
+++ b/Dockerfile_ros1_18_04
@@ -39,11 +39,10 @@ RUN	cd $WORKSPACE &&\
 # When a user runs a command we will run this code before theirs
 # This will allow for using the manual focal length if it fails to init
 # https://github.com/ethz-asl/kalibr/pull/346
-ENTRYPOINT export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1 && \
-	# /bin/bash -c "source \"$WORKSPACE/devel/setup.bash\"" && \ 
-	cd $WORKSPACE && \
-	/bin/bash
+RUN echo "export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1" >> /root/.bashrc && \
+    echo 'source "$WORKSPACE/devel/setup.bash"' >> /root/.bashrc
 
+ENTRYPOINT ["/bin/bash"]
 
 
 

--- a/Dockerfile_ros1_20_04
+++ b/Dockerfile_ros1_20_04
@@ -35,10 +35,10 @@ RUN	cd $WORKSPACE &&\
 # When a user runs a command we will run this code before theirs
 # This will allow for using the manual focal length if it fails to init
 # https://github.com/ethz-asl/kalibr/pull/346
-ENTRYPOINT export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1 && \
-	# /bin/bash -c "source \"$WORKSPACE/devel/setup.bash\"" && \ 
-	cd $WORKSPACE && \
-	/bin/bash
+RUN echo "export KALIBR_MANUAL_FOCAL_LENGTH_INIT=1" >> /root/.bashrc && \
+    echo 'source "$WORKSPACE/devel/setup.bash"' >> /root/.bashrc
+
+ENTRYPOINT ["/bin/bash"]
 
 
 


### PR DESCRIPTION
At the moment, the Docker `ENTRYPOINT` doesn't source the `$WORKSPACE/devel/setup.bash` causing `rosrun` not to be available in the Docker container on launch. 

This change adds the export and source to `/root/.bashrc` making sure that on launch the ROS environment is sourced and `KALIBR_MANUAL_FOCAL_LENGTH_INIT` exported.  