### PR TITLE
Remove the manually added GPG key in Dockerfile 18

### DIFF
--- a/Dockerfile_ros1_18_04
+++ b/Dockerfile_ros1_18_04
@@ -1,8 +1,5 @@
 FROM osrf/ros:melodic-desktop-full
 
-# Add expired GPG key
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
-
 # Dependencies we use, catkin tools is very good build system
 # https://github.com/ethz-asl/kalibr/wiki/installation
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Seems like the missing Ubuntu 18 GPG keys have been fixed in the meantime, so adding the GPG key manually is no longer required. It anyways seems to only have caused issues as the keyserver didn't respond occasionally.

