### PR TITLE
Update import order in kalibr_calibrate_cameras to fix cv_bridge_boost exception

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 print("importing libraries")
 import rosbag
+import cv2
 import cv_bridge
 
 import sm
@@ -11,7 +12,6 @@ import aslam_cv_backend as acvb
 import kalibr_common as kc
 import kalibr_camera_calibration as kcc
 
-import cv2
 import os
 import numpy as np
 import multiprocessing


### PR DESCRIPTION
This pr fixes an exception i hit on 20.04 Noetic running in a vm on amd64, need to import `cv2` before `cv_bridge`

```
parallels@ros1vm:~/aatb_ws/src/sparepack_misc/calib$ rosrun kalibr kalibr_calibrate_cameras  --target ../target/april_6x6.yaml  --models pinhole-radtan pinhole-radtan  --topics /oak/left/image_raw /oak/right/image_raw  --bag ../bag/all.bag
importing libraries
Traceback (most recent call last):
  File "/home/parallels/kalibr_ws/devel/lib/kalibr/kalibr_calibrate_cameras", line 15, in <module>
    exec(compile(fh.read(), python_script, 'exec'), context)
  File "/home/parallels/kalibr_ws/src/kalibr/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras", line 4, in <module>
    import cv_bridge
  File "/opt/ros/noetic/lib/python3/dist-packages/cv_bridge/__init__.py", line 6, in <module>
    from cv_bridge.boost.cv_bridge_boost import cvtColorForDisplay, getCvType
SystemError: initialization of cv_bridge_boost raised unreported exception
```

https://github.com/ros-perception/vision_opencv/issues/339
https://answers.ros.org/question/362388/cv_bridge_boost-raised-unreported-exception-when-importing-cv_bridge/