### PR TITLE
Don't generate aprilgrid targets if size < 3*3

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_create_target_pdf
+++ b/aslam_offline_calibration/kalibr/python/kalibr_create_target_pdf
@@ -92,6 +92,10 @@ def generateAprilBoard(canvas, n_cols, n_rows, tagSize, tagSpacing=0.25, tagFami
         print("[ERROR]: Invalid tagSpacing specified.  [0-1.0] of tagSize")
         sys.exit(0)
 
+    if(n_cols<3 or n_rows<3):
+        print("[ERROR]: The size of Aprilgrid targets must be greater than 3*3.")
+        sys.exit(0)
+
     if skipIds is None:
         skip_ids = []
         


### PR DESCRIPTION
Hello, I got an error trying to calibrate a camera using a 5\*2 april grid and based on [this issue](https://github.com/ethz-asl/kalibr/issues/370#issuecomment-655530264) it has to be 3\*3 minimum.
I've done my commit in browser so update it if necessary