### PR TITLE
Lazy multiprocess target extraction

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_common/TargetExtractor.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/TargetExtractor.py
@@ -1,5 +1,5 @@
 import sm
-
+import os
 import numpy as np
 import sys
 import multiprocessing
@@ -11,80 +11,65 @@ import time
 import copy
 import cv2
 
-def multicoreExtractionWrapper(detector, taskq, resultq, clearImages, noTransformation):    
-    while 1:
-        try:
-            task = taskq.get_nowait()
-        except queue.Empty:
-            return
-        idx = task[0]
-        stamp = task[1]
-        image = task[2]
-        
-        if noTransformation:
-            success, obs = detector.findTargetNoTransformation(stamp, np.array(image))
-        else:
-            success, obs = detector.findTarget(stamp, np.array(image))
-            
-        if clearImages:
-            obs.clearImage()
-        if success:
-            resultq.put( (obs, idx) )
+def multicoreExtractionWrapper(args):
+    # Unpack arguments
+    detector, timestamp, image, clearImages, noTransformation = args
+
+    # Perform detection
+    np_image = np.array(image)
+    if noTransformation:
+        success, obs = detector.findTargetNoTransformation(timestamp, np_image)
+    else:
+        success, obs = detector.findTarget(timestamp, np_image)
+
+    if clearImages:
+        obs.clearImage()
+
+    return obs if success else None
 
 def extractCornersFromDataset(dataset, detector, multithreading=False, numProcesses=None, clearImages=True, noTransformation=False):
-    print("Extracting calibration target corners")    
+    print("Extracting calibration target corners")
     targetObservations = []
     numImages = dataset.numImages()
-    
+
     # prepare progess bar
     iProgress = sm.Progress2(numImages)
     iProgress.sample()
-            
-    if multithreading:   
+
+    if multithreading:
         if not numProcesses:
-            numProcesses = max(1,multiprocessing.cpu_count()-1)
-        try:      
-            manager = multiprocessing.Manager()
-            resultq = manager.Queue()
-            manager2 = multiprocessing.Manager()
-            taskq = manager2.Queue()
-            
-            for idx, (timestamp, image) in enumerate(dataset.readDataset()):
-                taskq.put( (idx, timestamp, image) )
-                
-            plist=list()
-            for pidx in range(0, numProcesses):
-                detector_copy = copy.copy(detector)
-                p = multiprocessing.Process(target=multicoreExtractionWrapper, args=(detector_copy, taskq, resultq, clearImages, noTransformation, ))
-                p.start()
-                plist.append(p)
-            
-            #wait for results
-            last_done=0
-            while 1:
-                if all([not p.is_alive() for p in plist]):
-                    time.sleep(0.1)
-                    break
-                done = numImages-taskq.qsize()
-                sys.stdout.flush()
-                if (done-last_done) > 0:
-                    iProgress.sample(done-last_done)
-                last_done = done
-                time.sleep(0.5)
-            resultq.put('STOP')
-        except Exception as e:
-            raise RuntimeError("Exception during multithreaded extraction: {0}".format(e))
-        
-        #get result sorted by time (=idx)
-        if resultq.qsize() > 1:
-            targetObservations = [[]]*(resultq.qsize()-1)
-            for lidx, data in enumerate(iter(resultq.get, 'STOP')):
-                obs=data[0]; time_idx = data[1]
-                targetObservations[lidx] = (time_idx, obs)
-            targetObservations = list(zip(*sorted(targetObservations, key=lambda tup: tup[0])))[1]
-        else:
-            targetObservations=[]
-    
+            # Get available CPU count. Prefer `os.sched_getaffinity` if it's available as that
+            # works when the CPUs avaialble to the process are restricted:
+            # https://stackoverflow.com/a/55423170
+            if "sched_getaffinity" in dir(os):
+                numProcesses = len(os.sched_getaffinity(0))
+            else:
+                numProcesses = os.cpu_count() or 1
+
+            # Leave one CPU core free
+            numProcesses = max(1, numProcesses - 1)
+
+        # Create a pool of worker processes
+        with multiprocessing.Pool(processes=numProcesses) as pool:
+            # Build a generator of tasks to avoid loading everything in memory at once
+            tasks = (
+                (copy.copy(detector), ts, img, clearImages, noTransformation)
+                for ts, img in dataset.readDataset()
+            )
+
+            # Use imap to lazily (one by one) exccute the tasks in the process pool
+            results_iter = pool.imap(multicoreExtractionWrapper, tasks)
+
+            # Get results as they finish. imap returns results in the order the tasks
+            # are submitted. That's the same order as the timestamp
+            targetObservations = []
+            done_count = 0
+            for obs in results_iter:
+                if obs is not None:
+                    targetObservations.append(obs)
+                done_count += 1
+                iProgress.sample()
+
     #single threaded implementation
     else:
         for timestamp, image in dataset.readDataset():
@@ -101,10 +86,10 @@ def extractCornersFromDataset(dataset, detector, multithreading=False, numProces
     if len(targetObservations) == 0:
         print("\r")
         sm.logFatal("No corners could be extracted for camera {0}! Check the calibration target configuration and dataset.".format(dataset.topic))
-    else:    
+    else:
         print("\r  Extracted corners for %d images (of %d images)                              " % (len(targetObservations), numImages))
 
     #close all opencv windows that might be open
     cv2.destroyAllWindows()
-    
+
     return targetObservations

--- a/aslam_offline_calibration/kalibr/python/kalibr_common/TargetExtractor.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/TargetExtractor.py
@@ -1,7 +1,6 @@
 import sm
 import os
 import numpy as np
-import sys
 import multiprocessing
 try:
    import queue
@@ -44,7 +43,7 @@ def extractCornersFromDataset(dataset, detector, multithreading=False, numProces
             if "sched_getaffinity" in dir(os):
                 numProcesses = len(os.sched_getaffinity(0))
             else:
-                numProcesses = os.cpu_count() or 1
+                numProcesses = multiprocessing.cpu_count()
 
             # Leave one CPU core free
             numProcesses = max(1, numProcesses - 1)


### PR DESCRIPTION
When using longer datasets or larger image resolutions, kalibr uses a large amount of memory during corner extraction.

That's because all inputs needed for the corner extraction (including all images in the dataset) are duplicated `numProcesses` times when each process forks.

This PR simplifies the code and uses lazy multiprocessing to feed inputs to the process pool only when needed (one-by-one).
See a comparison below of the memory consumption **before** and **after** this PR with a dataset of 1920x1080 images:

![ram](https://github.com/user-attachments/assets/2c820744-7cb2-481d-aa28-9080d5cbf9af)

Peak memory usage is reduced by more than 50%.

CPU usage is more or less the same - seems less "spiky" now:

![cpu](https://github.com/user-attachments/assets/21101968-9337-4691-98b5-af7cc1bc49a3)

I've also ran the code in the PR on the sample dataset to make sure there's no unintended degradation:

**Command:**
```
rosrun kalibr kalibr_calibrate_cameras \
 	--target april_6x6.yaml \
 	--models pinhole-radtan pinhole-radtan \
 	--topics /cam0/image_raw /cam1/image_raw \
 	--bag cam_april.bag \
 	--bag-freq 10.0
```

**Camera chain before this PR:**
```
cam0:
  cam_overlaps: [1]
  camera_model: pinhole
  distortion_coeffs: [-0.2894411946323578, 0.07962117717814395, 0.00019362566733012107, 2.0633489114325153e-05]
  distortion_model: radtan
  intrinsics: [459.16620162518655, 457.8283425910929, 366.56421591367956, 248.93486745674633]
  resolution: [752, 480]
  rostopic: /cam0/image_raw
cam1:
  T_cn_cnm1:
  - [0.9999975833780851, 0.0021876991183658436, 0.00021727987704355133, -0.10996992818618531]
  - [-0.0021905046383791527, 0.9999012408498518, 0.01388201124994388, 0.0003967599845687264]
  - [-0.0001868887548949044, -0.013882453654949846, 0.9999036166316727, -0.0006390066744876479]
  - [0.0, 0.0, 0.0, 1.0]
  cam_overlaps: [0]
  camera_model: pinhole
  distortion_coeffs: [-0.28702698964616846, 0.0774641314753513, -9.0868908124502e-05, 1.191942692999466e-05]
  distortion_model: radtan
  intrinsics: [457.8635851933246, 456.4589896582416, 379.35599660413214, 255.87526793697964]
  resolution: [752, 480]
  rostopic: /cam1/image_raw

```

**Camera chain after this PR:**
```
cam0:
  cam_overlaps: [1]
  camera_model: pinhole
  distortion_coeffs: [-0.28646742048247464, 0.07664440221166424, 0.00037989530732547436, -4.092622872711382e-06]
  distortion_model: radtan
  intrinsics: [459.2480732747205, 457.9630133876875, 366.85529050387214, 248.14762195518594]
  resolution: [752, 480]
  rostopic: /cam0/image_raw
cam1:
  T_cn_cnm1:
  - [0.9999972253522178, 0.0022194793620354293, 0.0007894296777357621, -0.10995275408589618]
  - [-0.002230016923524006, 0.9999049229804217, 0.013607792768362957, 0.0004232690628729674]
  - [-0.0007591524059026039, -0.01360951545307229, 0.999907098072989, -0.0005893580755146163]
  - [0.0, 0.0, 0.0, 1.0]
  cam_overlaps: [0]
  camera_model: pinhole
  distortion_coeffs: [-0.2861004711786593, 0.07657158365440236, 5.9945048063776784e-05, -7.586504253593691e-06]
  distortion_model: radtan
  intrinsics: [458.1502957674771, 456.7543594159104, 379.3836585373581, 255.19745143306127]
  resolution: [752, 480]
  rostopic: /cam1/image_raw
```

There's small difference but I think that's just the run-to-run variance.

Maybe this addresses #22, hard to say since that issue is very old. 
