### PR TITLE
Fix the code for imu+mocap calibration.

### DIFF
--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_imu_mocap
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_imu_mocap
@@ -228,7 +228,7 @@ def main():
 
     print("Exporting poses...")
     posesFile = bagtag + "-poses-imumocap-imu0.csv"
-    util.exportPoses(iCal, filename=posesFile)
+    mocap_util.exportPosesHamilton(iCal, filename=posesFile)
     print("  Poses written to {0}".format(posesFile))
     # posesFile = bagtag + "-poses-imumocap-mocap0.csv"
     # mocap_util.exportPoses(iCal, filename=posesFile)

--- a/aslam_offline_calibration/kalibr/python/kalibr_common/MocapDatasetReader.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/MocapDatasetReader.py
@@ -121,7 +121,7 @@ class BagMocapDatasetReader(object):
             timestamp = acv.Time(self.timestamp_corrector.getLocalTime(data.header.stamp.to_sec()))
         else:
             timestamp = acv.Time(data.header.stamp.secs, data.header.stamp.nsecs)
-        quat = np.array([data.transform.rotation.x, data.transform.rotation.y, data.transform.rotation.z, data.transform.rotation.w])
-        pos = np.array([data.transform.translation.x, data.transform.translation.y, data.transform.translation.z])
+        quat = np.array([data.pose.orientation.x, data.pose.orientation.y, data.pose.orientation.z, data.pose.orientation.w])
+        pos = np.array([data.pose.position.x, data.pose.position.y, data.pose.position.z])
 
         return (timestamp, quat, pos)

--- a/aslam_offline_calibration/kalibr/python/kalibr_imu_mocap_calibration/MocapSensors.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_imu_mocap_calibration/MocapSensors.py
@@ -59,6 +59,8 @@ class IccMocap():
 
     class MocapMeasurement(object):
         def __init__(self, stamp, quat, pos):
+            # There is a required conjugation between Hamilton's quaternion and JPL convention.
+            quat[:3] = -quat[:3]
             self.T_w_m = sm.Transformation(quat, pos)
             self.stamp = stamp
 

--- a/aslam_offline_calibration/kalibr/python/kalibr_imu_mocap_calibration/MocapUtil.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_imu_mocap_calibration/MocapUtil.py
@@ -259,7 +259,7 @@ np.set_printoptions(suppress=True)
 #     if showOnScreen:
 #         plotter.show()
 
-def exportPoses(cself, filename="poses_imu0.csv"):
+def exportPosesHamilton(cself, filename="poses_imu0.csv"):
     # Append our header, and select times at IMU rate
     f = open(filename, 'w')
     print("#timestamp, p_RS_R_x [m], p_RS_R_y [m], p_RS_R_z [m], q_RS_w [], q_RS_x [], q_RS_y [], q_RS_z []", file=f)
@@ -272,12 +272,12 @@ def exportPoses(cself, filename="poses_imu0.csv"):
     # Times are in nanoseconds
     # ETH groundtruth csv format [t,q,p]
     for time in times:
-        T_w_b = sm.Transformation(sm.rt2Transform(bodyspline.orientation(time), bodyspline.position(time)))
-        T_b_m = cself.Mocap.getResultTrafoImuToMocap().inverse()
-        T_m_w = T_w_b * T_b_m
-        time_mocap = time - cself.Mocap.getResultTimeShift()
-        print("{:.0f},".format(1e9 * time_mocap) + ",".join(map("{:.6f}".format, T_m_w.t()))
-              + ",{:.6f},".format(T_m_w.q()[3]) + ",".join(map("{:.6f}".format, T_m_w.q()[0:3])), file=f)
+        position = bodyspline.position(time)
+        orientation = sm.r2quat(bodyspline.orientation(time))
+        # There is a required conjugation between Hamilton's quaternion and JPL convention.
+        orientation[:3] = -orientation[:3]
+        print("{:.0f},".format(1e9 * time) + ",".join(map("{:.6f}".format, position)) \
+               + ",{:.6f},".format(orientation[3]) + ",".join(map("{:.6f}".format, orientation[0:3])) , file=f)
 
 # def saveResultTxt(cself, filename='cam_imu_result.txt'):
 #     f = open(filename, 'w')


### PR DESCRIPTION
### Overview
We fixed the IMU-Motion Capture (MoCap) calibration tool. It can now perform the spatiotemporal extrinsic calibration between the IMU and the MoCap trajectory. This enables the conversion of the raw MoCap data into a trajectory referenced to the IMU local frame, meeting the requirements of tasks such as VI-SLAM benchmarking.

### Command
One can run the IMU - MoCap calibration function with the following code:
```bash 
rosrun kalibr kalibr_calibrate_imu_mocap \
  --bag your_bag_name.bag \
  --imu your_imu_config.yaml \
  --imu-models calibrated \
  --topic /your_mocap_topic
```
For more parameter descriptions, one can use the following command to view the help information:
```bash 
rosrun kalibr kalibr_calibrate_imu_mocap -h
```

### Verification
We conducted verification on the EuRoC dataset and our own MoCap dataset. The code functions properly. As shown in the figures below, the running log and output results for one sequence of the EuRoC dataset indicate that the estimated trajectory is basically consistent with the one published by EuRoC.

<img width="415" alt="log" src="https://github.com/user-attachments/assets/80e332cb-15d6-4f2a-a225-4abc7d10d734" />

<img width="511" alt="traj_result" src="https://github.com/user-attachments/assets/569d31e6-a222-480e-bc34-c68a7080dee0" />

### Notes
Meanwhile, we also noticed that the calibration accuracy is higher when there is sufficient motion excitation. Therefore, we recommend performing an additional calibration operation first and applying the calibration results to all subsequent data collection processes.

