### PR TITLE
Use value of KALIBR_MANUAL_FOCAL_LENGTH_INIT as initial guess

### DIFF
--- a/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
+++ b/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
@@ -780,18 +780,16 @@ bool PinholeProjection<DISTORTION_T>::initializeIntrinsics(const std::vector<Gri
     }
   }
   if(f_guesses.empty()) {
+    std::cout << "Initialization of focal length failed. Provide manual initialization: " << std::endl;
     const char* manual_input = std::getenv("KALIBR_MANUAL_FOCAL_LENGTH_INIT");
     if(manual_input != nullptr) {
-      double input_guess;
-      std::cout << "Initialization of focal length failed. Provide manual initialization: " << std::endl;
-      std::cin >> input_guess;
+      double input_guess = std::stod(manual_input);
       SM_ASSERT_GT(std::runtime_error, input_guess, 0.0, 
                 "Focal length needs to be positive.");
       std::cout << "Initializing focal length to " << input_guess << std::endl;
       f_guesses.push_back(input_guess);
     } else {
-      std::cout << "Initialization of focal length failed. You can enable"
-        << " manual input by setting 'KALIBR_MANUAL_FOCAL_LENGTH_INIT'." << std::endl;
+      std::cout << "You can provide an initial guess using the env. variable 'KALIBR_MANUAL_FOCAL_LENGTH_INIT'." << std::endl;
       return false;
     }
   }

--- a/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
+++ b/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
@@ -783,7 +783,7 @@ bool PinholeProjection<DISTORTION_T>::initializeIntrinsics(const std::vector<Gri
     std::cout << "Initialization of focal length failed. Provide manual initialization: " << std::endl;
     const char* manual_input = std::getenv("KALIBR_MANUAL_FOCAL_LENGTH_INIT");
     double input_guess;
-    if(manual_input != nullptr) {
+    if(manual_input != nullptr && manual_input[0] != '\0') {
       input_guess = std::stod(manual_input);
     } else {
       std::cin >> input_guess;

--- a/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
+++ b/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
@@ -780,12 +780,13 @@ bool PinholeProjection<DISTORTION_T>::initializeIntrinsics(const std::vector<Gri
     }
   }
   if(f_guesses.empty()) {
-    std::cout << "Initialization of focal length failed. Provide manual initialization: " << std::endl;
+    std::cout << "Initialization of focal length failed." << std::endl;
     const char* manual_input = std::getenv("KALIBR_MANUAL_FOCAL_LENGTH_INIT");
     double input_guess;
     if(manual_input != nullptr && manual_input[0] != '\0') {
       input_guess = std::stod(manual_input);
     } else {
+      std::cout << "Provide manual initialization: " << std::endl;
       std::cin >> input_guess;
     }
     SM_ASSERT_GT(std::runtime_error, input_guess, 0.0, 

--- a/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
+++ b/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
@@ -782,16 +782,16 @@ bool PinholeProjection<DISTORTION_T>::initializeIntrinsics(const std::vector<Gri
   if(f_guesses.empty()) {
     std::cout << "Initialization of focal length failed. Provide manual initialization: " << std::endl;
     const char* manual_input = std::getenv("KALIBR_MANUAL_FOCAL_LENGTH_INIT");
+    double input_guess;
     if(manual_input != nullptr) {
-      double input_guess = std::stod(manual_input);
-      SM_ASSERT_GT(std::runtime_error, input_guess, 0.0, 
-                "Focal length needs to be positive.");
-      std::cout << "Initializing focal length to " << input_guess << std::endl;
-      f_guesses.push_back(input_guess);
+      input_guess = std::stod(manual_input);
     } else {
-      std::cout << "You can provide an initial guess using the env. variable 'KALIBR_MANUAL_FOCAL_LENGTH_INIT'." << std::endl;
-      return false;
+      std::cin >> input_guess;
     }
+    SM_ASSERT_GT(std::runtime_error, input_guess, 0.0, 
+              "Focal length needs to be positive.");
+    std::cout << "Initializing focal length to " << input_guess << std::endl;
+    f_guesses.push_back(input_guess);
   }
   // Get the median of the guesses if available.
   double f0 = PinholeHelpers::medianOfVectorElements(f_guesses);


### PR DESCRIPTION
Instead of using as a way to enable/disable manual input of focal length, use the value itself as the initial guess.

Avoids interruptions for manual input during processing when the "factory" focal length is known.
If `KALIBR_MANUAL_FOCAL_LENGTH_INIT` is not set or is empty, the user is prompted for an initial value.