### PR TITLE
Fix circlegrid corners

### DIFF
--- a/aslam_cv/aslam_cameras/include/aslam/cameras/GridCalibrationTargetCirclegrid.hpp
+++ b/aslam_cv/aslam_cameras/include/aslam/cameras/GridCalibrationTargetCirclegrid.hpp
@@ -59,6 +59,9 @@ class GridCalibrationTargetCirclegrid : public GridCalibrationTargetBase {
   bool computeObservation(const cv::Mat &image, Eigen::MatrixXd &outImagePoints,
                           std::vector<bool> &outCornerObserved) const;
 
+  /// \brief receive the circlegrid options
+  const CirclegridOptions options() const {return _options;}
+
  private:
   /// \brief initialize the object
   void initialize();

--- a/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/OmniProjection.hpp
+++ b/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/OmniProjection.hpp
@@ -1,3 +1,5 @@
+#include <aslam/cameras/GridCalibrationTargetCirclegrid.hpp>
+
 namespace aslam {
 
 namespace cameras {
@@ -773,7 +775,15 @@ bool OmniProjection<DISTORTION_T>::initializeIntrinsics(const std::vector<GridCa
       }
 
       // MIN_CORNERS is an arbitrary threshold for the number of corners
-      const size_t MIN_CORNERS = 4;
+      size_t MIN_CORNERS = 4;
+
+      // allow asymmetric circle grids with half of the minimum corners as 2 asymmetric columns are treated a 1
+      if (const aslam::cameras::GridCalibrationTargetCirclegrid* circleGrid = dynamic_cast<const aslam::cameras::GridCalibrationTargetCirclegrid*>(&target)){
+        if (circleGrid->options().useAsymmetricCirclegrid){
+          MIN_CORNERS = MIN_CORNERS / 2;
+        }
+      }
+
       if (count > MIN_CORNERS)
       {
         // Resize P to fit with the count of valid points.

--- a/aslam_cv/aslam_cameras/src/OmniCameraGeometry.cpp
+++ b/aslam_cv/aslam_cameras/src/OmniCameraGeometry.cpp
@@ -523,7 +523,15 @@ bool OmniProjection::initializeIntrinsics(
           }
         }
 
-        const int MIN_CORNERS = 8;
+        int MIN_CORNERS = 8;
+
+        // allow asymmetric circle grids with half of the minimum corners as 2 asymmetric columns are treated a 1
+        if (const aslam::cameras::GridCalibrationTargetCirclegrid* circleGrid = dynamic_cast<const aslam::cameras::GridCalibrationTargetCirclegrid*>(&target)){
+          if (circleGrid->options().useAsymmetricCirclegrid){
+            MIN_CORNERS = MIN_CORNERS / 2;
+          }
+        }
+
         // MIN_CORNERS is an arbitrary threshold for the number of corners
         if (count > MIN_CORNERS) {
           // Resize P to fit with the count of valid points.


### PR DESCRIPTION
# Description

The double sphere calibration using asymmetric circlegrid patterns fails on common pattern sizes. The intrinsics are not getting initialized properly though the calibration imagery and detection looks fine. 

```
[DEBUG] [1741341647.594944]: calibrateIntrinsics: intrinsics guess: [0. 0. 0. 0. 0. 0.]
[DEBUG] [1741341647.597938]: calibrateIntrinsics: distortion guess: []          
[DEBUG] [1741341647.601171]: calibrateIntrinsics: adding camera error terms for 84 calibration targets
[DEBUG] [1741341647.635674]: calibrateIntrinsics: added 3024 camera error terms                                                                                 
No linear system solver set in the options. Defaulting to the sparse_cholesky solver
Using the sparse_cholesky linear system solver                                                                                                                  
Using the levenberg_marquardt trust region policy                               
[DEBUG] [1741341647.639727]: Before optimization:                                                                                                               
[DEBUG] [1741341647.645821]:  Reprojection error squarred (camL):  mean 243182.28379997588, median 233123.48769726523, std: 135897.35797906824
No linear system solver set in the options. Defaulting to the sparse_cholesky solver
Using the sparse_cholesky linear system solver                                  
Using the levenberg_marquardt trust region policy                               
Initializing                                                                                                                                                    
Optimization problem initialized with 170 design variables and 3024 error terms 
The Jacobian matrix is 6048 x 510                                                                                                                               
[0.0]: J: 7.35383e+08                                                           
[1]: J: nan, dJ: nan, deltaX: nan, LM - lambda:10 mu:2                                                                                                          
[DEBUG] [1741341647.662138]: calibrateIntrinsics: guess for intrinsics cam: [nan nan nan nan nan nan]
[DEBUG] [1741341647.664781]: calibrateIntrinsics: guess for distortion cam: []  
        Projection initialized to: [nan nan nan nan nan nan]                                                                                                    
        Distortion initialized to: []                                           
```

# Issue Cause
Asymmetric circlegrids define a column pairs as one column. Due to that common pattern sizes (e.g. 8 columns or 4 column pairs) internally get treated as half of the real columns in the sensor of the `GridCalibrationTagetBase` class (e.g. 4). This leads to the issue that the defined minimum corner threshold of `4` mostly won't be reached and the observations get dropped.

# Solution
Taking into account the target type when evaluating the minimum corner threshold in the `OmniProjection` and `OmniCameraGeometry` classes fixes that and enables the double sphere calibration with common asymmetric circlegrid pattern sizes.