### PR TITLE
Charuco + CVAT input + distortion init from CLI + fix solvePNP bug

### DIFF
--- a/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
+++ b/aslam_cv/aslam_cameras/include/aslam/cameras/implementation/PinholeProjection.hpp
@@ -827,6 +827,35 @@ size_t PinholeProjection<DISTORTION_T>::computeReprojectionError(
   return count;
 }
 
+inline bool arePointsCollinear(cv::InputArray points)
+{
+  // This is the same algorithm as in cv::findExtrinsicCameraParams2() that decides
+  // whether the points are planar or not. However, that algorithm fails in case
+  // the points are both coplanar and collinear (W[2] / W[1] yields nan in such case).
+  if (points.rows() * points.cols() < 3)
+    return true;
+
+  cv::Mat opoints = points.getMat();
+  double MM[9] = {0}, V[9] = {0}, W[3] = {0};
+  cv::Mat _MM(3, 3, CV_64F, MM);
+  cv::Mat matV(3, 3, CV_64F, V);
+  cv::Mat matW(3, 1, CV_64F, W);
+
+  cv::Mat matM;
+  opoints.convertTo(matM, CV_64F);
+  cv::Scalar Mc = cv::mean(matM);
+  cv::Mat _Mc(1, 3, CV_64F, Mc.val);
+
+  matM = matM.reshape(1, std::max(opoints.cols, opoints.rows));
+  cv::mulTransposed(matM, _MM, true, _Mc);
+  cv::SVDecomp(_MM, matW, cv::noArray(), matV, cv::SVD::MODIFY_A);
+
+  if (W[1] == 0 || !std::isfinite(W[2] / W[1]))
+    return true;
+
+  return false;
+}
+
 /// \brief estimate the transformation of the camera with respect to the calibration target
 ///        On success out_T_t_c is filled in with the transformation that takes points from
 ///        the camera frame to the target frame
@@ -868,16 +897,23 @@ bool PinholeProjection<DISTORTION_T>::estimateTransformation(
   Ps.resize(count);
   Ms.resize(count);
 
+  // We know the Ps points are coplanar (because of their construction, they all lie in plane z=0).
+  // However, if the points are collinear, we cannot estimate the target pose uniquely.
+  if (arePointsCollinear(Ps))
+    return false;
+
   std::vector<double> distCoeffs(4, 0.0);
 
   cv::Mat rvec(3, 1, CV_64F);
   cv::Mat tvec(3, 1, CV_64F);
 
+  // solvePnP() for coplanar points needs at least 4 points (which are not collinear)
   if (Ps.size() < 4)
     return false;
 
   // Call the OpenCV pnp function.
-  cv::solvePnP(Ps, Ms, cv::Mat::eye(3, 3, CV_64F), distCoeffs, rvec, tvec);
+  if (!cv::solvePnP(Ps, Ms, cv::Mat::eye(3, 3, CV_64F), distCoeffs, rvec, tvec))
+    return false;
 
   // convert the rvec/tvec to a transformation
   cv::Mat C_camera_model = cv::Mat::eye(3, 3, CV_64F);

--- a/aslam_cv/aslam_cameras_charuco/CMakeLists.txt
+++ b/aslam_cv/aslam_cameras_charuco/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(aslam_cameras_charuco)
+
+ADD_DEFINITIONS(-DASLAM_USE_ROS)
+
+find_package(catkin REQUIRED COMPONENTS
+  sm_python
+  aslam_cameras
+  numpy_eigen
+  sm_common
+  sm_logging
+  sm_boost
+  sm_eigen
+  python_module
+)
+find_package(OpenCV REQUIRED)
+find_package(Boost REQUIRED COMPONENTS serialization system)
+find_package(Eigen3 REQUIRED)
+
+catkin_package(
+  LIBRARIES ${PROJECT_NAME}
+  INCLUDE_DIRS include
+  DEPENDS OpenCV Boost
+)
+
+include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} 
+  src/GridCalibrationTargetCharuco.cpp
+)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBS} ${Boost_LIBRARIES})
+
+add_python_export_library(${PROJECT_NAME}_python python/aslam_cameras_charuco
+  src/module.cpp
+)
+target_link_libraries(${PROJECT_NAME}_python ${PROJECT_NAME})
+
+##################
+## Installation ##
+##################
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY include/
+  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+)

--- a/aslam_cv/aslam_cameras_charuco/include/aslam/cameras/GridCalibrationTargetCharuco.hpp
+++ b/aslam_cv/aslam_cameras_charuco/include/aslam/cameras/GridCalibrationTargetCharuco.hpp
@@ -1,0 +1,169 @@
+#ifndef ASLAM_GRID_CALIBRATION_TARGET_CHARUCO_HPP
+#define ASLAM_GRID_CALIBRATION_TARGET_CHARUCO_HPP
+
+#include <vector>
+#include <boost/shared_ptr.hpp>
+#include <Eigen/Core>
+#include <opencv2/core/core.hpp>
+#include <opencv2/aruco/charuco.hpp>
+#include <sm/assert_macros.hpp>
+#include <aslam/cameras/GridCalibrationTargetBase.hpp>
+#include <boost/serialization/export.hpp>
+
+namespace aslam {
+namespace cameras {
+
+class GridCalibrationTargetCharuco : public GridCalibrationTargetBase {
+ public:
+  SM_DEFINE_EXCEPTION(Exception, std::runtime_error);
+
+  typedef boost::shared_ptr<GridCalibrationTargetCharuco> Ptr;
+  typedef boost::shared_ptr<const GridCalibrationTargetCharuco> ConstPtr;
+
+  //target extraction options
+  struct CharucoOptions {
+    CharucoOptions() :
+      doSubpixRefinement(true),
+      maxSubpixDisplacement2(1.5),
+      showExtractionVideo(false),
+      minTagsForValidObs(2),
+      minBorderDistance(3.0),
+      blackTagBorder(1) {};
+
+    //options
+    /// \brief subpixel refinement of extracted corners
+    bool doSubpixRefinement;
+
+    /// \brief max. displacement squarred in subpixel refinement  [px^2]
+    double maxSubpixDisplacement2;
+
+    /// \brief show video during extraction
+    bool showExtractionVideo;
+
+    /// \brief min. number of tags for a valid observation
+    unsigned int minTagsForValidObs;
+
+    /// \brief min. distance form image border for valid points [px]
+    unsigned int minBorderDistance;
+
+    /// \brief size of black border around the tag code bits (in pixels)
+    unsigned int blackTagBorder;
+
+    /// \brief Serialization support
+    enum {CLASS_SERIALIZATION_VERSION = 1};
+    BOOST_SERIALIZATION_SPLIT_MEMBER();
+    template<class Archive>
+    void save(Archive & ar, const unsigned int /*version*/) const
+    {
+       ar << BOOST_SERIALIZATION_NVP(doSubpixRefinement);
+       ar << BOOST_SERIALIZATION_NVP(maxSubpixDisplacement2);
+       ar << BOOST_SERIALIZATION_NVP(showExtractionVideo);
+       ar << BOOST_SERIALIZATION_NVP(minTagsForValidObs);
+       ar << BOOST_SERIALIZATION_NVP(minBorderDistance);
+       ar << BOOST_SERIALIZATION_NVP(blackTagBorder);
+    }
+    template<class Archive>
+    void load(Archive & ar, const unsigned int /*version*/)
+    {
+       ar >> BOOST_SERIALIZATION_NVP(doSubpixRefinement);
+       ar >> BOOST_SERIALIZATION_NVP(maxSubpixDisplacement2);
+       ar >> BOOST_SERIALIZATION_NVP(showExtractionVideo);
+       ar >> BOOST_SERIALIZATION_NVP(minTagsForValidObs);
+       ar >> BOOST_SERIALIZATION_NVP(minBorderDistance);
+       ar >> BOOST_SERIALIZATION_NVP(blackTagBorder);
+    }
+  };
+
+  /// \brief initialize based on checkerboard geometry
+  GridCalibrationTargetCharuco(size_t tagRows, size_t tagCols, double tagSize,
+                               double tagSpacing, const std::string& dictName,
+                               size_t markerSize, size_t nMarkers,
+                               const CharucoOptions &options = CharucoOptions());
+
+  virtual ~GridCalibrationTargetCharuco() {};
+
+  /// \brief extract the calibration target points from an image and write to an observation
+  bool computeObservation(const cv::Mat & image,
+                          Eigen::MatrixXd & outImagePoints,
+                          std::vector<bool> &outCornerObserved) const;
+
+ private:
+  /// \brief initialize the object
+  void initialize();
+
+  /// \brief initialize the grid with the points
+  void createGridPoints();
+
+  /// \brief size of a tag [m]
+  double _tagSize;
+
+  /// \brief space between tags (tagSpacing [m] = tagSize * tagSpacing)
+  double _tagSpacing;
+
+  /// \brief Name of the Charuco dictionary (one of PREDEFINED_DICTIONARY_NAME without the DICT_ prefix).
+  std::string _dictName;
+
+  /// \brief Bit size of marker (used only when _dictName is empty).
+  size_t _markerSize;
+
+  /// \brief Number of markers in dictionary (used only when _dictName is empty).
+  size_t _nMarkers;
+
+  /// \brief target extraction options
+  CharucoOptions _options;
+
+  cv::Ptr<cv::aruco::Dictionary> _dict;
+  cv::Ptr<cv::aruco::CharucoBoard> _board;
+  cv::Ptr<cv::aruco::DetectorParameters> _params;
+
+  ///////////////////////////////////////////////////
+  // Serialization support
+  ///////////////////////////////////////////////////
+ public:
+  enum {CLASS_SERIALIZATION_VERSION = 1};
+  BOOST_SERIALIZATION_SPLIT_MEMBER()
+
+  //serialization ctor
+  GridCalibrationTargetCharuco();
+
+ protected:
+  friend class boost::serialization::access;
+
+  template<class Archive>
+  void save(Archive & ar, const unsigned int /* version */) const {
+    boost::serialization::void_cast_register<GridCalibrationTargetCharuco, GridCalibrationTargetBase>(
+          static_cast<GridCalibrationTargetCharuco *>(NULL),
+          static_cast<GridCalibrationTargetBase *>(NULL));
+    ar << BOOST_SERIALIZATION_BASE_OBJECT_NVP(GridCalibrationTargetBase);
+    ar << BOOST_SERIALIZATION_NVP(_tagSize);
+    ar << BOOST_SERIALIZATION_NVP(_tagSpacing);
+    ar << BOOST_SERIALIZATION_NVP(_options);
+    ar << BOOST_SERIALIZATION_NVP(_dictName);
+    ar << BOOST_SERIALIZATION_NVP(_markerSize);
+    ar << BOOST_SERIALIZATION_NVP(_nMarkers);
+  }
+  template<class Archive>
+  void load(Archive & ar, const unsigned int /* version */) {
+    boost::serialization::void_cast_register<GridCalibrationTargetCharuco, GridCalibrationTargetBase>(
+          static_cast<GridCalibrationTargetCharuco *>(NULL),
+          static_cast<GridCalibrationTargetBase *>(NULL));
+    ar >> BOOST_SERIALIZATION_BASE_OBJECT_NVP(GridCalibrationTargetBase);
+    ar >> BOOST_SERIALIZATION_NVP(_tagSize);
+    ar >> BOOST_SERIALIZATION_NVP(_tagSpacing);
+    ar >> BOOST_SERIALIZATION_NVP(_options);
+    ar >> BOOST_SERIALIZATION_NVP(_dictName);
+    ar >> BOOST_SERIALIZATION_NVP(_markerSize);
+    ar >> BOOST_SERIALIZATION_NVP(_nMarkers);
+    initialize();
+  }
+};
+
+
+}  // namespace cameras
+}  // namespace aslam
+
+SM_BOOST_CLASS_VERSION(aslam::cameras::GridCalibrationTargetCharuco);
+SM_BOOST_CLASS_VERSION(aslam::cameras::GridCalibrationTargetCharuco::CharucoOptions);
+BOOST_CLASS_EXPORT_KEY(aslam::cameras::GridCalibrationTargetCharuco)
+
+#endif /* ASLAM_GRID_CALIBRATION_TARGET_CHARUCO_HPP */

--- a/aslam_cv/aslam_cameras_charuco/package.xml
+++ b/aslam_cv/aslam_cameras_charuco/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <name>aslam_cameras_charuco</name>
+  <description>aslam_cameras_charuco</description>
+  <version>0.0.1</version>
+  <maintainer email="paulfurgale@mavt.ethz.ch">Paul Furgale</maintainer>
+  <author>Paul Furgale</author>
+  <author>Martin Pecka</author>
+  <license>New BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>sm_python</build_depend>
+  <build_depend>aslam_cameras</build_depend>
+  <build_depend>numpy_eigen</build_depend>
+  <build_depend>sm_common</build_depend>
+  <build_depend>sm_logging</build_depend>
+  <build_depend>sm_boost</build_depend>
+  <build_depend>sm_eigen</build_depend>
+  <build_depend>python_module</build_depend>
+</package>

--- a/aslam_cv/aslam_cameras_charuco/python/aslam_cameras_charuco/__init__.py
+++ b/aslam_cv/aslam_cameras_charuco/python/aslam_cameras_charuco/__init__.py
@@ -1,0 +1,16 @@
+# Import the numpy to Eigen type conversion.
+import numpy_eigen
+import os
+import aslam_cv
+
+isCompiled = False
+pathToSo = os.path.dirname(os.path.realpath(__file__))
+if os.path.isfile(os.path.join(pathToSo,"libaslam_cameras_charuco_python.so")):
+    # Import the the C++ exports from your package library.
+    from .libaslam_cameras_charuco_python import *
+    # Import other files in the directory
+    # from mypyfile import *
+    isCompiled = True
+else:
+    print("Warning: the package aslam_cameras_charuco_python is not compiled.")
+    PACKAGE_IS_NOT_COMPILED = True;

--- a/aslam_cv/aslam_cameras_charuco/setup.py
+++ b/aslam_cv/aslam_cameras_charuco/setup.py
@@ -1,0 +1,12 @@
+
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['aslam_cameras_charuco'],
+    package_dir={'':'python'})
+
+setup(**setup_args)

--- a/aslam_cv/aslam_cameras_charuco/src/GridCalibrationTargetCharuco.cpp
+++ b/aslam_cv/aslam_cameras_charuco/src/GridCalibrationTargetCharuco.cpp
@@ -1,0 +1,296 @@
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <Eigen/Core>
+#include <opencv2/core/core.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/aruco/charuco.hpp>
+#include <boost/make_shared.hpp>
+#include <sm/assert_macros.hpp>
+#include <sm/logging.hpp>
+#include <aslam/cameras/GridCalibrationTargetCharuco.hpp>
+
+namespace aslam {
+namespace cameras {
+
+/// \brief Construct aCharuco calibration target
+///        tagRows:    number of tags in y-dir (gridRows = tagRows - 1)
+///        tagCols:    number of tags in x-dir (gridCols = tagCols - 1)
+///        tagSize:    size of a tag [m]
+///        tagSpacing: space between tags (in tagSpacing [m] = tagSpacing*tagSize)
+///        dictName:   Name of the Charuco dictionary (one of PREDEFINED_DICTIONARY_NAME without DICT_ prefix).
+///        markerSize: size of the marker in bits (e.g. 4 for 4x4_50 markers) (only used if dictName is empty).
+///        nMarkers:   number of markers in the dictionary (e.g. 50 for 4x4_50 markers) (only used if dictName is empty).
+GridCalibrationTargetCharuco::GridCalibrationTargetCharuco(
+    size_t tagRows, size_t tagCols, double tagSize, double tagSpacing, const std::string& dictName,
+    size_t markerSize, size_t nMarkers, const CharucoOptions &options)
+    : GridCalibrationTargetBase(tagRows - 1, tagCols - 1),
+      _tagSize(tagSize),
+      _tagSpacing(tagSpacing),
+      _dictName(dictName),
+      _markerSize(markerSize),
+      _nMarkers(nMarkers),
+      _options(options) {
+  SM_ASSERT_GT(Exception, tagSize, 0.0, "tagSize has to be positive");
+  SM_ASSERT_GT(Exception, tagSpacing, 0.0, "tagSpacing has to be positive");
+
+  // allocate memory for the grid points
+  _points.resize(size(), 3);
+
+  //start the output window if requested
+  initialize();
+}
+
+//protected ctor for serialization
+GridCalibrationTargetCharuco::GridCalibrationTargetCharuco()
+{}
+
+cv::Ptr<cv::aruco::Dictionary> createDictionary(const std::string& dictName, size_t markerSize, size_t nMarkers)
+{
+  if (dictName == "4X4_50")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_4X4_50);
+  if (dictName == "4X4_100")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_4X4_100);
+  if (dictName == "4X4_250")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_4X4_250);
+  if (dictName == "4X4_100")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_4X4_1000);
+  if (dictName == "5X5_50")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_5X5_50);
+  if (dictName == "5X5_100")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_5X5_100);
+  if (dictName == "5X5_250")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_5X5_250);
+  if (dictName == "5X5_100")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_5X5_1000);
+  if (dictName == "6X6_50")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_50);
+  if (dictName == "6X6_100")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_100);
+  if (dictName == "6X6_250")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_250);
+  if (dictName == "6X6_100")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_1000);
+  if (dictName == "7X7_50")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_7X7_50);
+  if (dictName == "7X7_100")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_7X7_100);
+  if (dictName == "7X7_250")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_7X7_250);
+  if (dictName == "7X7_100")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_7X7_1000);
+  if (dictName == "ARUCO_ORIGINAL")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_ARUCO_ORIGINAL);
+  if (dictName == "APRILTAG_16h5")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_APRILTAG_16h5);
+  if (dictName == "APRILTAG_25h9")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_APRILTAG_25h9);
+  if (dictName == "APRILTAG_36h10")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_APRILTAG_36h10);
+  if (dictName == "APRILTAG_36h11")
+    return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_APRILTAG_36h11);
+
+  return cv::aruco::generateCustomDictionary(nMarkers, markerSize);
+}
+
+/// \brief initialize the object
+void GridCalibrationTargetCharuco::initialize()
+{
+  //initialize a normal grid (checkerboard and circlegrids)
+  createGridPoints();
+
+  if (_options.showExtractionVideo) {
+    cv::namedWindow("Charuco: Marker detections", cv::WINDOW_NORMAL);
+    cv::resizeWindow("Charuco: Marker detections", 640, 480);
+    cv::namedWindow("Charuco: Marker corners", cv::WINDOW_NORMAL);
+    cv::resizeWindow("Charuco: Marker corners", 640, 480);
+    cv::namedWindow("Charuco: Corner detections", cv::WINDOW_NORMAL);
+    cv::resizeWindow("Charuco: Corner detections", 640, 480);
+  }
+
+  //create the tag detector
+  _dict = createDictionary(_dictName, _nMarkers, _markerSize);
+  const auto squareLength = _tagSize * (1.0 + _tagSpacing);
+  const auto markerLength = _tagSize;
+  _board = cv::aruco::CharucoBoard::create(_cols + 1, _rows + 1, squareLength, markerLength, _dict);
+  _params = cv::aruco::DetectorParameters::create();
+  if (_options.doSubpixRefinement)
+    _params->cornerRefinementMethod = cv::aruco::CornerRefineMethod::CORNER_REFINE_SUBPIX;
+  _params->minDistanceToBorder = _options.minBorderDistance;
+  _params->markerBorderBits = _options.blackTagBorder;
+}
+
+/// \brief initialize a charuco grid
+void GridCalibrationTargetCharuco::createGridPoints() {
+  for (unsigned r = 0; r < _rows; r++) {
+    for (unsigned c = 0; c < _cols; c++) {
+      Eigen::Matrix<double, 1, 3> point;
+
+      point(0) = (c + 1) * (1 + _tagSpacing) * _tagSize;
+      point(1) = (r + 1) * (1 + _tagSpacing) * _tagSize;
+      point(2) = 0.0;
+
+      _points.row(static_cast<Eigen::Index>(gridCoordinatesToPoint(r, c))) = point;
+    }
+  }
+}
+
+/// \brief extract the calibration target points from an image and write to an observation
+bool GridCalibrationTargetCharuco::computeObservation(
+    const cv::Mat & image, Eigen::MatrixXd & outImagePoints,
+    std::vector<bool> &outCornerObserved) const {
+
+  bool success = true;
+
+  // detect the tags
+  std::vector<int> markerIds;
+  std::vector<std::vector<cv::Point2f> > markerCorners;
+  cv::aruco::detectMarkers(image, _board->dictionary, markerCorners, markerIds, _params);
+
+  //did we find enough tags?
+  if (markerCorners.size() < _options.minTagsForValidObs) {
+    success = false;
+
+    //immediate exit if we dont need to show video for debugging...
+    //if video is shown, exit after drawing video...
+    if (!_options.showExtractionVideo)
+      return success;
+  }
+
+  // Create a list of indices
+  std::vector<size_t> idx(markerIds.size());
+  std::iota(idx.begin(), idx.end(), 0);
+  std::stable_sort(idx.begin(), idx.end(),
+    [&markerIds](size_t i1, size_t i2) {return markerIds[i1] < markerIds[i2];});
+
+  // check for duplicate tagIds (--> if found: wild Aruco in image not belonging to calibration target)
+  // (only if we have more than 1 tag...)
+  if (markerIds.size() > 1) {
+    for (unsigned i = 0; i < markerIds.size() - 1; i++)
+      if (markerIds[idx[i]] == markerIds[idx[i + 1]]) {
+        //show the duplicate tags in the image
+        cv::destroyAllWindows();
+        cv::namedWindow("Wild Aruco detected. Hide them!");
+        cv::startWindowThread();
+
+        cv::Mat imageCopy = image.clone();
+        cv::cvtColor(imageCopy, imageCopy, cv::COLOR_GRAY2RGB);
+
+        //mark all duplicate tags in image
+        for (size_t j = 0; j < markerIds.size() - 1; j++) {
+          if (markerIds[idx[j]] == markerIds[idx[j + 1]]) {
+            std::vector<std::vector<cv::Point2f>> corners = {
+              markerCorners[idx[j]],
+              markerCorners[idx[j + 1]],
+            };
+            std::vector<int> ids = {
+              markerIds[idx[j]],
+              markerIds[idx[j + 1]],
+            };
+            cv::aruco::drawDetectedMarkers(imageCopy, corners, ids);
+          }
+        }
+
+        cv::putText(imageCopy, "Duplicate Aruco detected. Hide them.",
+                    cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
+                    CV_RGB(255,0,0), 2, 8, false);
+        cv::putText(imageCopy, "Press enter to exit...", cv::Point(50, 80),
+                    cv::FONT_HERSHEY_SIMPLEX, 0.8, CV_RGB(255,0,0), 2, 8, false);
+        cv::imshow("Duplicate Aruco detected. Hide them", imageCopy);  // OpenCV call
+
+        // and exit
+        SM_FATAL_STREAM("\n[ERROR]: Found aruco not belonging to calibration board. Check the image for the tag and hide it.\n");
+
+        cv::waitKey();
+        exit(0);
+      }
+  }
+
+  //insert the observed points into the correct location of the grid point array
+  std::vector<cv::Point2f> charucoCorners;
+  std::vector<int> charucoIds;
+  if (markerIds.size() > 0) {
+    cv::aruco::interpolateCornersCharuco(markerCorners, markerIds, image, _board,
+      charucoCorners, charucoIds);
+  }
+
+  if (_options.showExtractionVideo) {
+    //image with refined (blue) and raw corners (red)
+    cv::Mat imageCopy1 = image.clone();
+    cv::cvtColor(imageCopy1, imageCopy1, cv::COLOR_GRAY2RGB);
+    for (unsigned i = 0; i < markerCorners.size(); i++)
+      for (unsigned j = 0; j < 4; j++) {
+        cv::circle(
+            imageCopy1,
+            cv::Point2f(markerCorners[i][j].x, markerCorners[i][j].y),
+              3, CV_RGB(0,0,255), 1);
+
+        if (!success)
+          cv::putText(imageCopy1, "Detection failed! (frame not used)",
+                      cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
+                      CV_RGB(255,0,0), 3, 8, false);
+      }
+
+    cv::imshow("Charuco: Marker corners", imageCopy1);  // OpenCV call
+    cv::waitKey(1);
+
+    /* copy image for modification */
+    cv::Mat imageCopy2 = image.clone();
+    cv::cvtColor(imageCopy2, imageCopy2, cv::COLOR_GRAY2RGB);
+    /* highlight detected tags in image */
+    cv::aruco::drawDetectedMarkers(imageCopy2, markerCorners, markerIds);
+
+    if (!success)
+      cv::putText(imageCopy2, "Detection failed! (frame not used)",
+                  cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
+                  CV_RGB(255,0,0), 3, 8, false);
+
+    cv::imshow("Charuco: Marker detections", imageCopy2);  // OpenCV call
+    cv::waitKey(1);
+
+    /* copy image for modification */
+    cv::Mat imageCopy3 = image.clone();
+    cv::cvtColor(imageCopy3, imageCopy3, cv::COLOR_GRAY2RGB);
+    /* highlight detected tags in image */
+    cv::aruco::drawDetectedCornersCharuco(imageCopy3, charucoCorners, charucoIds);
+
+    if (!success)
+      cv::putText(imageCopy3, "Detection failed! (frame not used)",
+                  cv::Point(50, 50), cv::FONT_HERSHEY_SIMPLEX, 0.8,
+                  CV_RGB(255,0,0), 3, 8, false);
+
+    cv::imshow("Charuco: Corner detections", imageCopy3);  // OpenCV call
+    cv::waitKey(1);
+
+    //if success is false exit here (delayed exit if _options.showExtractionVideo=true for debugging)
+    if (!success)
+      return success;
+  }
+
+  outCornerObserved.resize(size(), false);
+  outImagePoints.resize(size(), 2);
+
+  for (size_t i = 0; i < charucoIds.size(); ++i)
+  {
+    const auto cornerId = static_cast<size_t>(charucoIds[i]);
+    if (cornerId >= _board->chessboardCorners.size())
+      continue;
+    outImagePoints(static_cast<Eigen::Index>(cornerId), 0) = charucoCorners[i].x;
+    outImagePoints(static_cast<Eigen::Index>(cornerId), 1) = charucoCorners[i].y;
+    outCornerObserved[cornerId] = true;
+  }
+
+  //succesful observation
+  return success;
+}
+
+}  // namespace cameras
+}  // namespace aslam
+
+//export explicit instantions for all included archives
+#include <sm/boost/serialization.hpp>
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_IMPLEMENT(aslam::cameras::GridCalibrationTargetCharuco);
+BOOST_CLASS_EXPORT_IMPLEMENT(aslam::cameras::GridCalibrationTargetCharuco::CharucoOptions);

--- a/aslam_cv/aslam_cameras_charuco/src/GridCalibrationTargetCharuco.cpp
+++ b/aslam_cv/aslam_cameras_charuco/src/GridCalibrationTargetCharuco.cpp
@@ -16,8 +16,8 @@ namespace aslam {
 namespace cameras {
 
 /// \brief Construct a Charuco calibration target
-///        tagCols:    number of chessboard squares in x-direction (= OpenCV squaresX)
 ///        tagRows:    number of chessboard squares in y-direction (= OpenCV squaresY)
+///        tagCols:    number of chessboard squares in x-direction (= OpenCV squaresX)
 ///        tagSize:    ArUco marker side length [m] (= OpenCV markerLength)
 ///        tagSpacing: ratio such that chessboard square length = tagSize * (1 + tagSpacing)
 ///                    i.e. tagSpacing = squareLength/markerLength - 1

--- a/aslam_cv/aslam_cameras_charuco/src/GridCalibrationTargetCharuco.cpp
+++ b/aslam_cv/aslam_cameras_charuco/src/GridCalibrationTargetCharuco.cpp
@@ -15,11 +15,12 @@
 namespace aslam {
 namespace cameras {
 
-/// \brief Construct aCharuco calibration target
-///        tagRows:    number of tags in y-dir (gridRows = tagRows - 1)
-///        tagCols:    number of tags in x-dir (gridCols = tagCols - 1)
-///        tagSize:    size of a tag [m]
-///        tagSpacing: space between tags (in tagSpacing [m] = tagSpacing*tagSize)
+/// \brief Construct a Charuco calibration target
+///        tagCols:    number of chessboard squares in x-direction (= OpenCV squaresX)
+///        tagRows:    number of chessboard squares in y-direction (= OpenCV squaresY)
+///        tagSize:    ArUco marker side length [m] (= OpenCV markerLength)
+///        tagSpacing: ratio such that chessboard square length = tagSize * (1 + tagSpacing)
+///                    i.e. tagSpacing = squareLength/markerLength - 1
 ///        dictName:   Name of the Charuco dictionary (one of PREDEFINED_DICTIONARY_NAME without DICT_ prefix).
 ///        markerSize: size of the marker in bits (e.g. 4 for 4x4_50 markers) (only used if dictName is empty).
 ///        nMarkers:   number of markers in the dictionary (e.g. 50 for 4x4_50 markers) (only used if dictName is empty).
@@ -55,7 +56,7 @@ cv::Ptr<cv::aruco::Dictionary> createDictionary(const std::string& dictName, siz
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_4X4_100);
   if (dictName == "4X4_250")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_4X4_250);
-  if (dictName == "4X4_100")
+  if (dictName == "4X4_1000")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_4X4_1000);
   if (dictName == "5X5_50")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_5X5_50);
@@ -63,7 +64,7 @@ cv::Ptr<cv::aruco::Dictionary> createDictionary(const std::string& dictName, siz
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_5X5_100);
   if (dictName == "5X5_250")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_5X5_250);
-  if (dictName == "5X5_100")
+  if (dictName == "5X5_1000")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_5X5_1000);
   if (dictName == "6X6_50")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_50);
@@ -71,7 +72,7 @@ cv::Ptr<cv::aruco::Dictionary> createDictionary(const std::string& dictName, siz
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_100);
   if (dictName == "6X6_250")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_250);
-  if (dictName == "6X6_100")
+  if (dictName == "6X6_1000")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_1000);
   if (dictName == "7X7_50")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_7X7_50);
@@ -79,7 +80,7 @@ cv::Ptr<cv::aruco::Dictionary> createDictionary(const std::string& dictName, siz
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_7X7_100);
   if (dictName == "7X7_250")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_7X7_250);
-  if (dictName == "7X7_100")
+  if (dictName == "7X7_1000")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_7X7_1000);
   if (dictName == "ARUCO_ORIGINAL")
     return cv::aruco::getPredefinedDictionary(cv::aruco::PREDEFINED_DICTIONARY_NAME::DICT_ARUCO_ORIGINAL);
@@ -111,7 +112,7 @@ void GridCalibrationTargetCharuco::initialize()
   }
 
   //create the tag detector
-  _dict = createDictionary(_dictName, _nMarkers, _markerSize);
+  _dict = createDictionary(_dictName, _markerSize, _nMarkers);
   const auto squareLength = _tagSize * (1.0 + _tagSpacing);
   const auto markerLength = _tagSize;
   _board = cv::aruco::CharucoBoard::create(_cols + 1, _rows + 1, squareLength, markerLength, _dict);

--- a/aslam_cv/aslam_cameras_charuco/src/module.cpp
+++ b/aslam_cv/aslam_cameras_charuco/src/module.cpp
@@ -1,0 +1,30 @@
+// It is extremely important to use this header
+// if you are using the numpy_eigen interface
+#include <aslam/cameras/GridCalibrationTargetCharuco.hpp>
+#include <numpy_eigen/boost_python_headers.hpp>
+#include <sm/python/boost_serialization_pickle.hpp>
+
+BOOST_PYTHON_MODULE(libaslam_cameras_charuco_python)
+{
+  using namespace boost::python;
+  using namespace aslam::cameras;
+
+  class_<GridCalibrationTargetCharuco::CharucoOptions>("CharucoOptions", init<>())
+    .def_readwrite("doSubpixRefinement", &GridCalibrationTargetCharuco::CharucoOptions::doSubpixRefinement)
+    .def_readwrite("showExtractionVideo", &GridCalibrationTargetCharuco::CharucoOptions::showExtractionVideo)
+    .def_readwrite("minTagsForValidObs", &GridCalibrationTargetCharuco::CharucoOptions::minTagsForValidObs)
+    .def_readwrite("minBorderDistance", &GridCalibrationTargetCharuco::CharucoOptions::minBorderDistance)
+    .def_readwrite("maxSubpixDisplacement2", &GridCalibrationTargetCharuco::CharucoOptions::maxSubpixDisplacement2)
+    .def_readwrite("blackTagBorder", &GridCalibrationTargetCharuco::CharucoOptions::blackTagBorder)
+    .def_pickle(sm::python::pickle_suite<GridCalibrationTargetCharuco::CharucoOptions>());
+
+  class_<GridCalibrationTargetCharuco, bases<GridCalibrationTargetBase>,
+      boost::shared_ptr<GridCalibrationTargetCharuco>, boost::noncopyable>(
+      "GridCalibrationTargetCharuco",
+      init<size_t, size_t, double, double, const std::string&, size_t, size_t, GridCalibrationTargetCharuco::CharucoOptions>(
+          "GridCalibrationTargetCharuco(size_t tagRows, size_t tagCols, double tagSize, double tagSpacing, const std::string& dictName, size_t markerSize, size_t nMarkers, CharucoOptions options)"))
+      .def(init<size_t, size_t, double, double, const std::string&, size_t, size_t>(
+          "GridCalibrationTargetCharuco(size_t tagRows, size_t tagCols, double tagSize, double tagSpacing, const std::string& dictName, size_t markerSize, size_t nMarkers)"))
+      .def(init<>("Do not use the default constructor. It is only necessary for the pickle interface"))
+      .def_pickle(sm::python::pickle_suite<GridCalibrationTargetCharuco>());
+}

--- a/aslam_offline_calibration/kalibr/CMakeLists.txt
+++ b/aslam_offline_calibration/kalibr/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   aslam_backend_python
   incremental_calibration_python
   aslam_cameras_april
+  aslam_cameras_charuco
   aslam_splines_python
   numpy_eigen
   python_module

--- a/aslam_offline_calibration/kalibr/package.xml
+++ b/aslam_offline_calibration/kalibr/package.xml
@@ -15,6 +15,7 @@
   <build_depend>aslam_backend_python</build_depend>
   <build_depend>incremental_calibration_python</build_depend>
   <build_depend>aslam_cameras_april</build_depend>
+  <build_depend>aslam_cameras_charuco</build_depend>
   <build_depend>aslam_splines_python</build_depend>
   <build_depend>numpy_eigen</build_depend>
   <build_depend>python_module</build_depend>

--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
@@ -24,11 +24,22 @@ import signal
 np.set_printoptions(suppress=True)
 
 def initBagDataset(bagfile, topic, from_to, freq):
-    print("\tDataset:          {0}".format(bagfile))
-    print("\tTopic:            {0}".format(topic))
-    reader = kc.BagImageDatasetReader(bagfile, topic, bag_from_to=from_to, bag_freq=freq)
-    print("\tNumber of images: {0}".format(reader.numImages()))
-    return reader
+    if bagfile.endswith(".bag"):
+        # BAG format
+        print("\tDataset:          {0}".format(bagfile))
+        print("\tTopic:            {0}".format(topic))
+        reader = kc.BagImageDatasetReader(bagfile, topic, bag_from_to=from_to, bag_freq=freq)
+        print("\tNumber of images: {0}".format(reader.numImages()))
+        return reader
+    elif bagfile.endswith(".xml"):
+        # CVAT format
+        print("\tDataset:          {0}".format(bagfile))
+        print("\tLabel:            {0}".format(topic))
+        reader = kc.CvatImageDatasetReader(bagfile, topic)
+        print("\tNumber of images: {0}".format(reader.numImages()))
+        return reader
+    else:
+        raise RuntimeError("Unknown dataset type")
 
 #available models
 cameraModels = { 'pinhole-radtan': acvb.DistortedPinhole,

--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
@@ -92,7 +92,11 @@ def parseArgs():
     
     groupTarget = parser.add_argument_group('Image synchronization')
     groupTarget.add_argument('--approx-sync', dest='max_delta_approxsync', type=float, default=0.02, help='Time tolerance for approximate image synchronization [s] (default: %(default)s)')
-    
+
+    initSettings = parser.add_argument_group('Initialization')
+    initSettings.add_argument('--init-proj', type=str, nargs='*', dest='initProj', help='Initialize projection parameters by this 4-tuple (one for each camera) (default: empty)')
+    initSettings.add_argument('--init-dist', type=str, nargs='*', dest='initDist', help='Initialize projection parameters by this 4-tuple (one for each camera) (default: empty)')
+
     groupCalibrator = parser.add_argument_group('Calibrator settings')
     groupCalibrator.add_argument('--qr-tol', type=float, default=0.02, dest='qrTol', help='The tolerance on the factors of the QR decomposition (default: %(default)s)')
     groupCalibrator.add_argument('--mi-tol', type=float, default=0.2, dest='miTol', help='The tolerance on the mutual information for adding an image. Higher means fewer images will be added. Use -1 to force all images. (default: %(default)s)')
@@ -184,8 +188,15 @@ def main():
             for obs in observations:
                 obsdb.addObservation(cam_id, obs)
 
+            proj_init = None
+            dist_init = None
+            if parsed.initProj is not None and len(parsed.initProj) >= cam_id:
+                proj_init = np.array(list(map(float, parsed.initProj[cam_id].split(','))))
+            if parsed.initDist is not None and len(parsed.initDist) >= cam_id:
+                dist_init = np.array(list(map(float, parsed.initDist[cam_id].split(','))))
+
             #initialize the intrinsics
-            if not cam.initGeometryFromObservations(observations):
+            if not cam.initGeometryFromObservations(observations, proj_init, dist_init):
                 raise RuntimeError("Could not initialize the intrinsics for camera with topic: {0}. Try to use --verbose and check whether the calibration target extraction is successful.".format(topic))
             
             print("\tProjection initialized to: %s" % cam.geometry.projection().getParameters().flatten())

--- a/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
+++ b/aslam_offline_calibration/kalibr/python/kalibr_calibrate_cameras
@@ -273,8 +273,12 @@ def main():
                 for bidx, baseline in enumerate(calibrator.baselines):
                     est_baselines.append( sm.Transformation(baseline.T()) )
                 T_tc_guess = graph.getTargetPoseGuess(timestamp, cameraList, est_baselines)
-                               
-                success = calibrator.addTargetView(timestamp, obs_tuple, T_tc_guess)
+
+                if T_tc_guess is not None:
+                    success = calibrator.addTargetView(timestamp, obs_tuple, T_tc_guess)
+                else:
+                    success = False
+                    sm.logInfo("Skipping view %r because target pose cannot be estimated" % (view_id,))
                 
                 #display process
                 if (verbose or (view_id % 25) == 0) and calibrator.estimator.getNumBatches()>0 and view_id>1:

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
@@ -4,6 +4,7 @@ from sm import PlotCollection
 from kalibr_common import ConfigReader as cr
 import aslam_cv as acv
 import aslam_cameras_april as acv_april
+import aslam_cameras_charuco as acv_charuco
 import aslam_cv_backend as acvb
 import aslam_backend as aopt
 import incremental_calibration as ic
@@ -115,6 +116,20 @@ class TargetDetector(object):
                                                                  targetParams['tagCols'], 
                                                                  targetParams['tagSize'], 
                                                                  targetParams['tagSpacing'], 
+                                                                 options)
+
+        elif targetType == 'charuco':
+            options = acv_charuco.CharucoOptions()
+            options.showExtractionVideo = showCorners
+
+            print(targetParams)
+            self.grid = acv_charuco.GridCalibrationTargetCharuco(targetParams['tagRows'],
+                                                                 targetParams['tagCols'],
+                                                                 targetParams['tagSize'],
+                                                                 targetParams['tagSpacing'],
+                                                                 targetParams['dictName'],
+                                                                 targetParams['markerSize'],
+                                                                 targetParams['nMarkers'],
                                                                  options)
         else:
             RuntimeError('Unknown calibration target type!')

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
@@ -8,6 +8,7 @@ import aslam_cameras_charuco as acv_charuco
 import aslam_cv_backend as acvb
 import aslam_backend as aopt
 import incremental_calibration as ic
+import kalibr_common as kc
 import kalibr_camera_calibration as kcc
 
 from matplotlib.backends.backend_pdf import PdfPages
@@ -47,6 +48,10 @@ class CameraGeometry(object):
 
         #create target detector
         self.ctarget = TargetDetector(targetConfig, self.geometry, showCorners=verbose)
+
+        if isinstance(dataset, kc.CvatImageDatasetReader):
+            self.ctarget.detector = kc.CvatImageDatasetDetector(
+                dataset, self.ctarget.grid, self.geometry, showCorners=verbose)
 
     def setDvActiveStatus(self, projectionActive, distortionActive, shutterActice):
         self.dv.projectionDesignVariable().setActive(projectionActive)

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraCalibrator.py
@@ -53,12 +53,17 @@ class CameraGeometry(object):
         self.dv.distortionDesignVariable().setActive(distortionActive)
         self.dv.shutterDesignVariable().setActive(shutterActice)
 
-    def initGeometryFromObservations(self, observations):
+    def initGeometryFromObservations(self, observations, init_proj=None, init_dist=None):
         #obtain focal length guess
         success = self.geometry.initializeIntrinsics(observations)
         if not success:
             sm.logError("initialization of focal length for cam with topic {0} failed  ".format(self.dataset.topic))
-        
+
+        if init_proj is not None:
+            self.geometry.projection().setParameters(init_proj)
+        if init_dist is not None:
+            self.geometry.projection().distortion().setParameters(init_dist)
+
         #in case of an omni model, first optimize over intrinsics only
         #(--> catch most of the distortion with the projection model)
         if self.model == acvb.DistortedOmni:

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraIntializers.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/CameraIntializers.py
@@ -218,6 +218,8 @@ def calibrateIntrinsics(cam_geometry, obslist, distortionActive=True, intrinsics
     target_pose_dvs=list()
     for obs in obslist: 
         success, T_t_c = cam_geometry.geometry.estimateTransformation(obs)
+        if not success:
+            continue
         target_pose_dv = addPoseDesignVariable(problem, T_t_c)
         target_pose_dvs.append(target_pose_dv)
         
@@ -318,6 +320,8 @@ def solveFullBatch(cameras, baseline_guesses, graph):
 
         #create a target pose dv for all target views (= T_cam0_w)
         T0 = graph.getTargetPoseGuess(timestamp, cameras, baseline_guesses)
+        if T0 is None:
+            continue
         target_pose_dv = addPoseDesignVariable(problem, T0)
         target_pose_dvs.append(target_pose_dv)
         

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_calibration/MulticamGraph.py
@@ -252,6 +252,7 @@ class MulticamCalibrationGraph(object):
                
         if not success:
             sm.logWarn("getTargetPoseGuess: solvePnP failed with solution: {0}".format(T_t_cN))
+            return None
         
         #transform it back to cam0 (T_t_cN --> T_t_c0)
         T_cN_c0 = sm.Transformation()

--- a/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
+++ b/aslam_offline_calibration/kalibr/python/kalibr_camera_validator
@@ -10,6 +10,7 @@ import sm
 import aslam_cv as acv
 import aslam_cv_backend as acvb
 import aslam_cameras_april as acv_april
+import aslam_cameras_charuco as acv_charuco
 import kalibr_common as kc
 
 import os
@@ -51,6 +52,15 @@ class CalibrationTargetDetector(object):
                                                             targetParams['tagCols'], 
                                                             targetParams['tagSize'], 
                                                             targetParams['tagSpacing'])
+
+        elif( targetType == 'charuco' ):
+            grid = acv_charuco.GridCalibrationTargetCharuco(targetParams['tagRows'],
+                                                            targetParams['tagCols'],
+                                                            targetParams['tagSize'],
+                                                            targetParams['tagSpacing'],
+                                                            targetParams['dictName'],
+                                                            targetParams['markerSize'],
+                                                            targetParams['nMarkers'])
         else:
             raise RuntimeError( "Unknown calibration target." )
         
@@ -134,7 +144,7 @@ class CameraChainValidator(object):
                     np_image = np.array(self.bridge.compressed_imgmsg_to_cv2(msg))
                     if len(np_image.shape) > 2 and np_image.shape[2] == 3:
                         np_image = cv2.cvtColor(np_image, cv2.COLOR_BGR2GRAY)
-                elif msg.encoding == "rgb8" or msg.encoding == "bgra8":
+                elif msg.encoding in ("rgb8", "bgra8", "bgr8", "rgba8"):
                     np_image = np.array(self.bridge.imgmsg_to_cv2(msg, "mono8"))
                 else:
                     np_image = np.array(self.bridge.imgmsg_to_cv2(msg))

--- a/aslam_offline_calibration/kalibr/python/kalibr_common/ConfigReader.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/ConfigReader.py
@@ -537,6 +537,7 @@ class CalibrationTargetParameters(ParametersBase):
     ###################################################
     def checkTargetType(self, target_type):
         targetTypes = ['aprilgrid', 
+                       'charuco',
                        'checkerboard',
                        'circlegrid']
         
@@ -601,7 +602,7 @@ class CalibrationTargetParameters(ParametersBase):
                             'asymmetricGrid': asymmetricGrid,
                             'targetType': targetType}
             
-        elif targetType == 'aprilgrid':
+        elif targetType in ('aprilgrid', 'charuco'):
             try:
                 tagRows = self.data["tagRows"]
                 tagCols = self.data["tagCols"]
@@ -624,7 +625,24 @@ class CalibrationTargetParameters(ParametersBase):
                             'tagSize': tagSize,
                             'tagSpacing': tagSpacing,
                             'targetType': targetType}
-            
+
+            if targetType == "charuco":
+                dictName = self.data.get("dictName", "")
+                markerSize = self.data.get("markerSize", 4)
+                nMarkers = self.data.get("nMarkers", 50)
+
+                if not isinstance(dictName, str):
+                    errList.append("invalid dictName (str)")
+                if not isinstance(markerSize, int) or markerSize < 3:
+                    errList.append("invalid markerSize (int>=3)")
+                if not isinstance(nMarkers, int) or nMarkers < 1:
+                    errList.append("invalid nMarkers (int>=1)")
+
+                targetParams.update(
+                    {'dictName': dictName,
+                     'markerSize': markerSize,
+                     'nMarkers': nMarkers})
+
         return targetParams
         
     ###################################################
@@ -644,7 +662,7 @@ class CalibrationTargetParameters(ParametersBase):
             print("  Cols", file=dest)
             print("    Count: {0}".format(targetParams['targetCols']), file=dest)
             print("    Distance: {0} [m]".format(targetParams['colSpacingMeters']), file=dest)
-        elif targetType == 'aprilgrid':
+        elif targetType in ('aprilgrid', 'charuco'):
             print("  Tags: ", file=dest)
             print("    Rows: {0}".format(targetParams['tagRows']), file=dest)
             print("    Cols: {0}".format(targetParams['tagCols']), file=dest)

--- a/aslam_offline_calibration/kalibr/python/kalibr_common/CvatImageDatasetReader.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/CvatImageDatasetReader.py
@@ -1,0 +1,151 @@
+import aslam_cv as acv
+import cv2
+import os
+import numpy as np
+import random
+import xml.etree.ElementTree as ET
+
+
+class CvatImageDatasetReaderIterator(object):
+  def __init__(self, dataset, shuffle):
+    self.dataset = dataset
+    self.idx = 0
+    self.idxs = list(range(dataset.numImages()))
+    if shuffle:
+      self.idxs = random.shuffle(self.idxs)
+
+  def __iter__(self):
+    return self
+
+  def next(self):
+    # required for python 2.x compatibility
+    idx = self.idx
+    self.idx += 1
+    if self.idx >= len(self.idxs):
+      raise StopIteration()
+    return self.dataset.getImage(self.idxs[idx])
+
+  def __next__(self):
+    idx = self.idx
+    self.idx += 1
+    if self.idx >= len(self.idxs):
+      raise StopIteration()
+    return self.dataset.getImage(self.idxs[idx])
+
+
+class CvatAnnotation(object):
+  def __init__(self, points_data, image_data):
+    self.id = int(image_data.attrib["id"])
+    self.image_name = image_data.attrib["name"]
+    self.width = int(image_data.attrib["width"])
+    self.height = int(image_data.attrib["height"])
+    self.points = list()
+    for p in points_data.attrib["points"].split(';'):
+      p1, p2 = p.split(',')
+      self.points.append(np.array([float(p1), float(p2)]))
+
+
+class CvatImageDatasetReader(object):
+  def __init__(self, annotations_file, label=None):
+    self.annotations_file = annotations_file
+    self.topic = label
+
+    tree = ET.parse(annotations_file)
+    root = tree.getroot()
+    assert(root.tag == 'annotations')
+
+    self.annotations = list()
+    self.annotations_by_id = dict()
+    for child in root:
+      if child.tag != "image":
+        continue
+      annotation_tag = None
+      for e in child:
+        if e.tag == 'points':
+          if label is None or e.attrib['label'] == label:
+            annotation_tag = e
+            break
+
+      if annotation_tag is not None:
+        annotation = CvatAnnotation(annotation_tag, child)
+        self.annotations.append(annotation)
+        self.annotations_by_id[annotation.id] = annotation
+
+  def __iter__(self):
+    # Reset the bag reading
+    return self.readDataset()
+
+  def readDataset(self):
+    return CvatImageDatasetReaderIterator(self, shuffle=False)
+
+  def readDatasetShuffle(self):
+    return CvatImageDatasetReaderIterator(self, shuffle=True)
+
+  def numImages(self):
+    return len(self.annotations)
+
+  def getImage(self, idx):
+    image_path = os.path.join(os.path.dirname(self.annotations_file),
+                              self.annotations[idx].image_name)
+    timestamp = acv.Time(self.annotations[idx].id, 0)
+    img = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
+    # return ID instead of timestamp
+    return timestamp, img
+
+
+class CvatImageDatasetDetector(object):
+  def __init__(self, dataset, grid, cameraGeometry, showCorners=False):
+    self.dataset = dataset
+    self.grid = grid
+    self.cameraGeometry = cameraGeometry
+    self.showCorners = showCorners
+
+    if self.showCorners:
+      cv2.namedWindow("CVAT: Corner detections")
+      cv2.resizeWindow("CVAT: Corner detections", 640, 480)
+
+  def target(self):
+    return self.grid
+
+  def findTargetNoTransformation(self, timestamp, image):
+    observation = acv.GridCalibrationTargetObservation(self.grid)
+    observation.setTime(timestamp)
+    observation.setImage(image)
+
+    id = timestamp.sec
+    if id not in self.dataset.annotations_by_id:
+      return False, observation
+
+    annotation = self.dataset.annotations_by_id[id]
+    assert isinstance(annotation, CvatAnnotation)
+
+    if self.showCorners:
+      img_copy = np.copy(image)
+
+    w = annotation.width
+    h = annotation.height
+    num_valid = 0
+    for i, p in enumerate(annotation.points):
+      if all(np.isfinite(p)) and 0 <= p[0] < w and 0 <= p[1] < h:
+        observation.updateImagePoint(i, p)
+        num_valid += 1
+        if self.showCorners:
+          cv2.circle(img_copy, (int(p[0]), int(p[1])), 3, color=(0, 0, 255), thickness=1)
+          cv2.circle(img_copy, (int(p[0]), int(p[1])), 4, color=(255, 255, 255), thickness=1)
+
+    if self.showCorners:
+      cv2.imshow("CVAT: Corner detections", img_copy)
+      cv2.waitKey(1)
+
+    return num_valid >= 4, observation
+
+  def findTarget(self, timestamp, image):
+    success, observation = self.findTargetNoTransformation(timestamp, image)
+    if not success:
+      return success, observation
+
+    success, tf = self.cameraGeometry.estimateTransformation(observation)
+    if success:
+      observation.set_T_t_c(tf)
+
+    return success, observation

--- a/aslam_offline_calibration/kalibr/python/kalibr_common/__init__.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_common/__init__.py
@@ -1,6 +1,7 @@
 # Import the numpy to Eigen type conversion.
 import numpy_eigen
 from .ConfigReader import *
+from .CvatImageDatasetReader import *
 from .ImageDatasetReader import *
 from .ImuDatasetReader import *
 from .TargetExtractor import *

--- a/aslam_offline_calibration/kalibr/python/kalibr_create_target_pdf
+++ b/aslam_offline_calibration/kalibr/python/kalibr_create_target_pdf
@@ -5,6 +5,7 @@
 from pyx import *
 import argparse
 import sys
+import cv2.aruco
 
 import math
 import numpy as np
@@ -132,6 +133,47 @@ def generateAprilBoard(canvas, n_cols, n_rows, tagSize, tagSpacing=0.25, tagFami
     c.text(pos[0]+0.6*tagSize, pos[0], caption)
 
 
+#tagSpaceing in % of tagSize
+def generateCharucoBoard(canvas, n_cols, n_rows, tagSize, tagSpacing=0.25, charucoDict="4x4_50"):
+
+    if(tagSpacing<0 or tagSpacing>1.0):
+        print("[ERROR]: Invalid tagSpacing specified.  [0-1.0] of tagSize")
+        sys.exit(0)
+
+    #convert to cm
+    tagSize = tagSize*100.0
+
+    #draw tags
+    if hasattr(cv2.aruco, "DICT_" + charucoDict):
+        d = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, "DICT_" + charucoDict))
+    else:
+        sizes, nMarkersStr = charucoDict.split("_", maxsplit=1)
+        markerSize = int(sizes.split('X', maxsplit=1)[0])
+        nMarkers = int(nMarkersStr)
+        d = cv2.aruco.custom_dictionary(nMarkers, markerSize)
+    board = cv2.aruco.CharucoBoard.create(n_cols, n_rows, (tagSpacing + 1.0) * tagSize, tagSize, d)
+    size = ( n_cols*(1+tagSpacing)*tagSize, n_rows*(1+tagSpacing)*tagSize)
+    cv2.aruco.drawPlanarBoard(board, size, canvas)
+
+    #draw axis
+    pos = (-1.5 * tagSpacing * tagSize, -1.5 * tagSpacing * tagSize)
+    canvas.stroke(path.line(pos[0], pos[1], pos[0] + tagSize * 0.3, pos[1]),
+                  [color.rgb.red,
+                   deco.earrow([deco.stroked([color.rgb.red, style.linejoin.round]),
+                                deco.filled([color.rgb.red])], size=tagSize * 0.10)])
+    canvas.text(pos[0] + tagSize * 0.3, pos[1], "x")
+
+    canvas.stroke(path.line(pos[0], pos[1], pos[0], pos[1] + tagSize * 0.3),
+                  [color.rgb.green,
+                   deco.earrow([deco.stroked([color.rgb.green, style.linejoin.round]),
+                                deco.filled([color.rgb.green])], size=tagSize * 0.10)])
+    canvas.text(pos[0], pos[1] + tagSize * 0.3, "y")
+
+    # text
+    caption = "{0}x{1} tags, size={2}cm and spacing={3}cm".format(n_cols, n_rows, tagSize, tagSpacing * tagSize)
+    canvas.text(pos[0] + 0.6 * tagSize, pos[0], caption)
+
+
 def generateCheckerboard(canvas, n_cols, n_rows, size_cols, size_rows):
     #convert to cm
     size_cols = size_cols*100.0
@@ -159,6 +201,8 @@ if __name__ == "__main__":
     usage="""
     Example Aprilgrid:
         kalibr_create_target_pdf --type apriltag --nx 6 --ny 6 --tsize 0.08 --tspace 0.3
+    Example Charuco:
+        kalibr_create_target_pdf --type charuco --nx 6 --ny 6 --tsize 0.08 --tspace 0.3
     Example Checkerboard:
         kalibr_create_target_pdf --type checkerboard --nx 6 --ny 6 -csx 0.05 --csy 0.1
     """
@@ -180,6 +224,9 @@ if __name__ == "__main__":
     aprilOptions.add_argument('--tspace', type=float, default=0.3, dest='tagspacing', help='The space between the tags in fraction of the edge size [0..1] (default: %(default)s)')
     aprilOptions.add_argument('--tfam', default='t36h11', dest='tagfamiliy', help='Familiy of April tags {0} (default: %(default)s)'.format(list(AprilTagCodes.TagFamilies.keys()))) 
     aprilOptions.add_argument('--skip-ids', default='', dest='skipIds', help='Space-separated list of tag ids to leave blank (default: none)')
+
+    charucoOptions = parser.add_argument_group('Charuco arguments')
+    charucoOptions.add_argument('--charucodict', default='4x4_50', dest='charucodict', help='Charuco dict type (default: 4x4_50)')
 
     checkerOptions = parser.add_argument_group('Checkerboard arguments')    
     checkerOptions.add_argument('--csx', type=float, default=0.05, dest='chessSzX', help='The size of one chessboard square in x direction [m] (default: %(default)s)')
@@ -204,6 +251,8 @@ if __name__ == "__main__":
     #draw the board
     if parsed.gridType == "apriltag":
         generateAprilBoard(canvas, parsed.n_cols, parsed.n_rows, parsed.tsize, parsed.tagspacing, parsed.tagfamiliy, parsed.skipIds)
+    if parsed.gridType == "charuco":
+        generateCharucoBoard(c, parsed.n_cols, parsed.n_rows, parsed.tsize, parsed.tagspacing, parsed.charucodict)
     elif parsed.gridType == "checkerboard":
         generateCheckerboard(c, parsed.n_cols, parsed.n_rows, parsed.chessSzX, parsed.chessSzY)
     else:

--- a/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
+++ b/aslam_offline_calibration/kalibr/python/kalibr_imu_camera_calibration/IccSensors.py
@@ -2,6 +2,7 @@ from __future__ import print_function #handle print in 2.x python
 import sm
 import aslam_cv as acv
 import aslam_cameras_april as acv_april
+import aslam_cameras_charuco as acv_charuco
 import aslam_splines as asp
 import aslam_backend as aopt
 import bsplines
@@ -103,6 +104,18 @@ class IccCamera():
                                                             targetParams['tagCols'], 
                                                             targetParams['tagSize'], 
                                                             targetParams['tagSpacing'], 
+                                                            options)
+        elif targetType == 'charuco':
+            options = acv_charuco.CharucoOptions()
+            options.showExtractionVideo = showExtraction
+
+            grid = acv_charuco.GridCalibrationTargetCharuco(targetParams['tagRows'],
+                                                            targetParams['tagCols'],
+                                                            targetParams['tagSize'],
+                                                            targetParams['tagSpacing'],
+                                                            targetParams['dictName'],
+                                                            targetParams['markerSize'],
+                                                            targetParams['nMarkers'],
                                                             options)
         else:
             raise RuntimeError( "Unknown calibration target." )


### PR DESCRIPTION
This PR combines 4 features I've recently developed. Sorry for batching them all in one PR, but it's easier for me that way. However, each of the 4 features comes in its own commit, so it should be possible to cherry-pick.

Improvements:
- (hopefully) fix #555 by checking that points are not collinear when estimating transform
- support Charuco boards
- support input as CVAT dataset in addition to BAG (manually clicked keypoints)
- allow initializing focal length and distortion from CLI (an improvement to the previous solution of #99 so that the optimization no longer requires manual input in the middle)